### PR TITLE
test: update suite to per-nation billing signatures (fixes #6)

### DIFF
--- a/tests/integration/test_nb_oauth_integration.py
+++ b/tests/integration/test_nb_oauth_integration.py
@@ -53,22 +53,26 @@ class MockDynamoDBTable:
         self.items: dict[str, dict[str, Any]] = {}
         if items:
             for item in items:
-                key = item.get("user_id") or item.get("tenant_id")
+                key = self._key(item)
                 if key:
                     self.items[key] = item
         self.update_calls: list[dict[str, Any]] = []
         self.put_calls: list[dict[str, Any]] = []
         self.get_calls: list[dict[str, Any]] = []
 
+    @staticmethod
+    def _key(data: dict[str, Any]) -> Any:
+        return data.get("nation_slug") or data.get("user_id") or data.get("tenant_id")
+
     def get_item(self, Key: dict[str, Any]) -> dict[str, Any]:
         self.get_calls.append(Key)
-        key = Key.get("user_id") or Key.get("tenant_id")
+        key = self._key(Key)
         if key and key in self.items:
             return {"Item": self.items[key]}
         return {}
 
     def put_item(self, Item: dict[str, Any]) -> None:
-        key = Item.get("user_id") or Item.get("tenant_id")
+        key = self._key(Item)
         if key:
             self.items[key] = Item
         self.put_calls.append(Item)
@@ -86,7 +90,7 @@ class MockDynamoDBTable:
             "ExpressionAttributeValues": ExpressionAttributeValues,
         })
         # Simulate the update
-        key = Key.get("user_id") or Key.get("tenant_id")
+        key = self._key(Key)
         if key and key in self.items:
             for attr_key, attr_val in ExpressionAttributeValues.items():
                 # Extract attribute name from :attr format
@@ -176,6 +180,7 @@ class TestOAuthCallbackIntegration:
             "nb_connected": False,
             "nb_needs_reauth": False,
         }])
+        nations_table = MockDynamoDBTable()
 
         secrets_client = MockSecretsManagerClient({
             "nat/nb-client-id": TEST_CLIENT_ID,
@@ -205,7 +210,9 @@ class TestOAuthCallbackIntegration:
         with (
             patch(
                 "src.lambdas.nb_oauth_callback.handler.get_dynamodb_resource",
-                return_value=MockDynamoDBResource({"users": users_table}),
+                return_value=MockDynamoDBResource(
+                    {"nations": nations_table, "users": users_table}
+                ),
             ),
             patch(
                 "src.lambdas.nb_oauth_callback.handler.get_secrets_manager_client",
@@ -230,8 +237,8 @@ class TestOAuthCallbackIntegration:
         assert call_args[0][0] == "POST"
         assert f"https://{TEST_NB_SLUG}.nationbuilder.com/oauth/token" in call_args[0][1]
 
-        # Verify tokens were stored in Secrets Manager
-        token_secret_name = f"nat/user/{TEST_USER_ID}/nb-tokens"
+        # Verify tokens were stored in Secrets Manager (per-nation path)
+        token_secret_name = f"nat/nation/{TEST_NB_SLUG}/nb-tokens"
         assert len(secrets_client.put_calls) > 0 or len(secrets_client.create_calls) > 0
 
         # Check if tokens exist in secrets
@@ -239,16 +246,21 @@ class TestOAuthCallbackIntegration:
         stored_tokens = json.loads(secrets_client.secrets[token_secret_name])
         assert stored_tokens["access_token"] == TEST_ACCESS_TOKEN
         assert stored_tokens["refresh_token"] == TEST_REFRESH_TOKEN
-        assert stored_tokens["nb_slug"] == TEST_NB_SLUG
+        assert stored_tokens["nation_slug"] == TEST_NB_SLUG
         assert "expires_at" in stored_tokens
 
-        # Verify user record was updated
+        # Verify nation connection record was created
+        assert len(nations_table.put_calls) == 1
+        nation = nations_table.put_calls[0]
+        assert nation["nation_slug"] == TEST_NB_SLUG
+        assert nation["nb_connected"] is True
+        assert nation["nb_needs_reauth"] is False
+
+        # Verify the user was linked to the nation
         assert len(users_table.update_calls) == 1
         update = users_table.update_calls[0]
         assert update["Key"] == {"user_id": TEST_USER_ID}
-        assert update["ExpressionAttributeValues"][":connected"] is True
         assert update["ExpressionAttributeValues"][":slug"] == TEST_NB_SLUG
-        assert update["ExpressionAttributeValues"][":needs_reauth"] is False
 
     def test_oauth_flow_reconnecting_user(self) -> None:
         """Test OAuth flow for a user who needs to reconnect (reauth)."""
@@ -259,14 +271,20 @@ class TestOAuthCallbackIntegration:
             "email": "test@example.com",
             "nb_connected": True,
             "nb_needs_reauth": True,
-            "nb_slug": TEST_NB_SLUG,
+            "nation_slug": TEST_NB_SLUG,
+        }])
+        # Nation previously connected but flagged as needing reauth
+        nations_table = MockDynamoDBTable([{
+            "nation_slug": TEST_NB_SLUG,
+            "nb_connected": True,
+            "nb_needs_reauth": True,
         }])
 
         # Existing token secret will be updated
         secrets_client = MockSecretsManagerClient({
             "nat/nb-client-id": TEST_CLIENT_ID,
             "nat/nb-client-secret": TEST_CLIENT_SECRET,
-            f"nat/user/{TEST_USER_ID}/nb-tokens": json.dumps({
+            f"nat/nation/{TEST_NB_SLUG}/nb-tokens": json.dumps({
                 "access_token": "old_token",
                 "refresh_token": "old_refresh",
             }),
@@ -292,7 +310,9 @@ class TestOAuthCallbackIntegration:
         with (
             patch(
                 "src.lambdas.nb_oauth_callback.handler.get_dynamodb_resource",
-                return_value=MockDynamoDBResource({"users": users_table}),
+                return_value=MockDynamoDBResource(
+                    {"nations": nations_table, "users": users_table}
+                ),
             ),
             patch(
                 "src.lambdas.nb_oauth_callback.handler.get_secrets_manager_client",
@@ -315,8 +335,8 @@ class TestOAuthCallbackIntegration:
         stored_tokens = json.loads(secrets_client.put_calls[0]["SecretString"])
         assert stored_tokens["access_token"] == TEST_ACCESS_TOKEN
 
-        # Verify nb_needs_reauth was cleared
-        update = users_table.update_calls[0]
+        # Verify nb_needs_reauth was cleared on the nation record
+        update = nations_table.update_calls[0]
         assert update["ExpressionAttributeValues"][":needs_reauth"] is False
 
     def test_oauth_flow_nb_api_error(self) -> None:
@@ -498,7 +518,7 @@ class TestOAuthCallbackIntegration:
         assert "connected" in response["headers"]["Location"].lower()
 
         # Verify empty refresh_token was stored
-        token_secret_name = f"nat/user/{TEST_USER_ID}/nb-tokens"
+        token_secret_name = f"nat/nation/{TEST_NB_SLUG}/nb-tokens"
         stored_tokens = json.loads(secrets_client.secrets[token_secret_name])
         assert stored_tokens["refresh_token"] == ""
 

--- a/tests/integration/test_stripe_webhook_integration.py
+++ b/tests/integration/test_stripe_webhook_integration.py
@@ -32,6 +32,7 @@ TEST_CUSTOMER_ID = "cus_integration_test_123"
 TEST_SUBSCRIPTION_ID = "sub_integration_test_456"
 TEST_EMAIL = "integration.test@example.com"
 TEST_TENANT_ID = "tenant_integration_789"
+TEST_NATION_SLUG = "integrationnation"
 
 
 def create_stripe_signature(payload: str, secret: str, timestamp: int | None = None) -> str:
@@ -69,7 +70,7 @@ class MockDynamoDBTable:
         self._items: dict[str, dict[str, Any]] = {}
         if items:
             for item in items:
-                key = item.get("tenant_id") or item.get("user_id")
+                key = self._key(item)
                 if key:
                     self._items[key] = item.copy()
         self.put_calls: list[dict[str, Any]] = []
@@ -77,8 +78,12 @@ class MockDynamoDBTable:
         self.query_calls: list[dict[str, Any]] = []
         self.query_results: list[dict[str, Any]] = []
 
+    @staticmethod
+    def _key(data: dict[str, Any]) -> Any:
+        return data.get("nation_slug") or data.get("tenant_id") or data.get("user_id")
+
     def put_item(self, Item: dict[str, Any]) -> None:
-        key = Item.get("tenant_id") or Item.get("user_id")
+        key = self._key(Item)
         if key:
             self._items[key] = Item.copy()
         self.put_calls.append(Item)
@@ -96,7 +101,7 @@ class MockDynamoDBTable:
             "ExpressionAttributeValues": ExpressionAttributeValues,
         })
         # Simulate update
-        key = Key.get("tenant_id") or Key.get("user_id")
+        key = self._key(Key)
         if key and key in self._items:
             for attr_key, attr_val in ExpressionAttributeValues.items():
                 attr_name = attr_key[1:]  # Remove leading :
@@ -115,37 +120,33 @@ class MockDynamoDBTable:
         return {"Items": self.query_results}
 
     def get_item(self, Key: dict[str, Any]) -> dict[str, Any]:
-        key = Key.get("tenant_id") or Key.get("user_id")
+        key = self._key(Key)
         if key and key in self._items:
             return {"Item": self._items[key]}
         return {}
 
 
 class MockDynamoDBResource:
-    """Mock DynamoDB resource."""
+    """Mock DynamoDB resource.
 
-    def __init__(
-        self,
-        tenants_table: MockDynamoDBTable,
-        users_table: MockDynamoDBTable,
-    ) -> None:
-        self.tenants_table = tenants_table
-        self.users_table = users_table
+    The webhook handler operates exclusively on the NationsTable, so a single
+    backing table is returned regardless of the requested table name.
+    """
+
+    def __init__(self, nations_table: MockDynamoDBTable) -> None:
+        self.nations_table = nations_table
 
     def Table(self, name: str) -> MockDynamoDBTable:
-        if "tenant" in name.lower():
-            return self.tenants_table
-        return self.users_table
+        return self.nations_table
 
 
 class TestCheckoutCompletedIntegration:
     """Integration tests for checkout.session.completed event."""
 
-    def test_new_subscription_creates_tenant_and_user(self) -> None:
-        """Test that a new checkout creates both tenant and user records."""
-        tenants_table = MockDynamoDBTable()
-        users_table = MockDynamoDBTable()
-        mock_resource = MockDynamoDBResource(tenants_table, users_table)
+    def test_new_subscription_creates_nation(self) -> None:
+        """Test that a new checkout creates a nation record."""
+        nations_table = MockDynamoDBTable()
+        mock_resource = MockDynamoDBResource(nations_table)
 
         # Create checkout completed event
         checkout_data = {
@@ -153,7 +154,7 @@ class TestCheckoutCompletedIntegration:
             "subscription": TEST_SUBSCRIPTION_ID,
             "customer_email": TEST_EMAIL,
             "customer_details": {"email": TEST_EMAIL},
-            "metadata": {"plan": "team"},
+            "metadata": {"plan": "team", "nation_slug": TEST_NATION_SLUG},
         }
         event_payload = create_webhook_event("checkout.session.completed", checkout_data)
         body = json.dumps(event_payload)
@@ -180,42 +181,30 @@ class TestCheckoutCompletedIntegration:
         assert response["statusCode"] == 200
         assert json.loads(response["body"]) == {"received": True}
 
-        # Verify tenant was created with correct data
-        assert len(tenants_table.put_calls) == 1
-        tenant = tenants_table.put_calls[0]
-        assert tenant["stripe_customer_id"] == TEST_CUSTOMER_ID
-        assert tenant["stripe_subscription_id"] == TEST_SUBSCRIPTION_ID
-        assert tenant["stripe_subscription_status"] == "active"
-        assert tenant["plan"] == "team"
-        assert tenant["queries_limit"] == PLAN_QUERY_LIMITS["team"]
-        assert tenant["queries_this_month"] == 0
-        assert "tenant_id" in tenant
-        assert "billing_cycle_start" in tenant
-
-        # Verify user was created
-        assert len(users_table.put_calls) == 1
-        user = users_table.put_calls[0]
-        assert user["email"] == TEST_EMAIL
-        assert user["role"] == "admin"
-        assert user["nb_connected"] is False
-        assert user["nb_needs_reauth"] is False
-        assert "tenant_id" in user
-        assert user["tenant_id"] == tenant["tenant_id"]
+        # Verify nation was created with correct data. New nations begin in a
+        # trial state; the paid plan/limit is set by subscription.updated.
+        assert len(nations_table.put_calls) == 1
+        nation = nations_table.put_calls[0]
+        assert nation["nation_slug"] == TEST_NATION_SLUG
+        assert nation["stripe_customer_id"] == TEST_CUSTOMER_ID
+        assert nation["stripe_subscription_id"] == TEST_SUBSCRIPTION_ID
+        assert nation["subscription_status"] == "trialing"
+        assert nation["admin_email"] == TEST_EMAIL
+        assert nation["queries_used_this_period"] == 0
+        assert "billing_period_start" in nation
 
     def test_existing_customer_not_duplicated(self) -> None:
-        """Test that existing customer's tenant is not duplicated."""
-        tenants_table = MockDynamoDBTable()
-        tenants_table.query_results = [{"tenant_id": TEST_TENANT_ID}]
-
-        users_table = MockDynamoDBTable()
-        users_table.query_results = [{"user_id": "existing-user"}]
-
-        mock_resource = MockDynamoDBResource(tenants_table, users_table)
+        """Test that an existing nation is updated, not duplicated."""
+        nations_table = MockDynamoDBTable([
+            {"nation_slug": TEST_NATION_SLUG, "stripe_customer_id": TEST_CUSTOMER_ID}
+        ])
+        mock_resource = MockDynamoDBResource(nations_table)
 
         checkout_data = {
             "customer": TEST_CUSTOMER_ID,
             "subscription": TEST_SUBSCRIPTION_ID,
             "customer_email": TEST_EMAIL,
+            "metadata": {"plan": "team", "nation_slug": TEST_NATION_SLUG},
         }
         event_payload = create_webhook_event("checkout.session.completed", checkout_data)
         body = json.dumps(event_payload)
@@ -239,21 +228,25 @@ class TestCheckoutCompletedIntegration:
             response = handler(lambda_event, None)
 
         assert response["statusCode"] == 200
-        # No new tenant should be created
-        assert len(tenants_table.put_calls) == 0
+        # No new nation should be created; the existing one is updated
+        assert len(nations_table.put_calls) == 0
+        assert len(nations_table.update_calls) == 1
 
     def test_checkout_with_different_plans(self) -> None:
-        """Test checkout creates correct query limits for each plan."""
+        """Test checkout applies the correct query limit per plan for an
+        already-existing nation (the plan/limit are set on the update path)."""
         for plan in ["starter", "team", "org"]:
-            tenants_table = MockDynamoDBTable()
-            users_table = MockDynamoDBTable()
-            mock_resource = MockDynamoDBResource(tenants_table, users_table)
+            nation_slug = f"nation_{plan}"
+            nations_table = MockDynamoDBTable([
+                {"nation_slug": nation_slug, "stripe_customer_id": f"{TEST_CUSTOMER_ID}_{plan}"}
+            ])
+            mock_resource = MockDynamoDBResource(nations_table)
 
             checkout_data = {
                 "customer": f"{TEST_CUSTOMER_ID}_{plan}",
                 "subscription": TEST_SUBSCRIPTION_ID,
                 "customer_email": TEST_EMAIL,
-                "metadata": {"plan": plan},
+                "metadata": {"plan": plan, "nation_slug": nation_slug},
             }
             event_payload = create_webhook_event("checkout.session.completed", checkout_data)
             body = json.dumps(event_payload)
@@ -277,9 +270,9 @@ class TestCheckoutCompletedIntegration:
                 response = handler(lambda_event, None)
 
             assert response["statusCode"] == 200
-            tenant = tenants_table.put_calls[0]
-            assert tenant["plan"] == plan
-            assert tenant["queries_limit"] == PLAN_QUERY_LIMITS[plan]
+            update = nations_table.update_calls[0]
+            assert update["ExpressionAttributeValues"][":plan"] == plan
+            assert update["ExpressionAttributeValues"][":limit"] == PLAN_QUERY_LIMITS[plan]
 
 
 class TestSubscriptionUpdatedIntegration:
@@ -287,17 +280,16 @@ class TestSubscriptionUpdatedIntegration:
 
     def test_subscription_status_update(self) -> None:
         """Test that subscription status is updated correctly."""
-        tenants_table = MockDynamoDBTable([{
-            "tenant_id": TEST_TENANT_ID,
+        nations_table = MockDynamoDBTable([{
+            "nation_slug": TEST_NATION_SLUG,
             "stripe_customer_id": TEST_CUSTOMER_ID,
-            "stripe_subscription_status": "trialing",
-            "plan": "starter",
-            "billing_cycle_start": "2025-01-01",
+            "subscription_status": "trialing",
+            "subscription_plan": "trial",
+            "billing_period_start": "2025-01-01",
         }])
-        tenants_table.query_results = [tenants_table._items[TEST_TENANT_ID]]
+        nations_table.query_results = [nations_table._items[TEST_NATION_SLUG]]
 
-        users_table = MockDynamoDBTable()
-        mock_resource = MockDynamoDBResource(tenants_table, users_table)
+        mock_resource = MockDynamoDBResource(nations_table)
 
         subscription_data = {
             "customer": TEST_CUSTOMER_ID,
@@ -331,24 +323,23 @@ class TestSubscriptionUpdatedIntegration:
         assert response["statusCode"] == 200
 
         # Verify update was made
-        assert len(tenants_table.update_calls) == 1
-        update = tenants_table.update_calls[0]
+        assert len(nations_table.update_calls) == 1
+        update = nations_table.update_calls[0]
         assert update["ExpressionAttributeValues"][":status"] == "active"
         assert update["ExpressionAttributeValues"][":plan"] == "team"
         assert update["ExpressionAttributeValues"][":limit"] == PLAN_QUERY_LIMITS["team"]
 
     def test_billing_cycle_reset(self) -> None:
         """Test that usage is reset when billing cycle changes."""
-        tenants_table = MockDynamoDBTable([{
-            "tenant_id": TEST_TENANT_ID,
+        nations_table = MockDynamoDBTable([{
+            "nation_slug": TEST_NATION_SLUG,
             "stripe_customer_id": TEST_CUSTOMER_ID,
-            "billing_cycle_start": "2025-01-01",
-            "queries_this_month": 150,  # Had usage in old cycle
+            "billing_period_start": "2025-01-01",
+            "queries_used_this_period": 150,  # Had usage in old cycle
         }])
-        tenants_table.query_results = [tenants_table._items[TEST_TENANT_ID]]
+        nations_table.query_results = [nations_table._items[TEST_NATION_SLUG]]
 
-        users_table = MockDynamoDBTable()
-        mock_resource = MockDynamoDBResource(tenants_table, users_table)
+        mock_resource = MockDynamoDBResource(nations_table)
 
         # New billing period starts February 1st
         new_period_start = 1738368000  # 2025-02-01 00:00:00 UTC
@@ -384,24 +375,24 @@ class TestSubscriptionUpdatedIntegration:
         assert response["statusCode"] == 200
 
         # Verify usage was reset
-        update = tenants_table.update_calls[0]
+        update = nations_table.update_calls[0]
         assert ":zero" in update["ExpressionAttributeValues"]
         assert update["ExpressionAttributeValues"][":zero"] == 0
-        assert "billing_cycle_start" in update["UpdateExpression"]
+        assert "billing_period_start" in update["UpdateExpression"]
+        assert "queries_used_this_period" in update["UpdateExpression"]
 
     def test_plan_upgrade(self) -> None:
         """Test that plan upgrade updates query limits."""
-        tenants_table = MockDynamoDBTable([{
-            "tenant_id": TEST_TENANT_ID,
+        nations_table = MockDynamoDBTable([{
+            "nation_slug": TEST_NATION_SLUG,
             "stripe_customer_id": TEST_CUSTOMER_ID,
-            "plan": "starter",
+            "subscription_plan": "nat",
             "queries_limit": PLAN_QUERY_LIMITS["starter"],
-            "billing_cycle_start": "2025-01-15",
+            "billing_period_start": "2025-01-15",
         }])
-        tenants_table.query_results = [tenants_table._items[TEST_TENANT_ID]]
+        nations_table.query_results = [nations_table._items[TEST_NATION_SLUG]]
 
-        users_table = MockDynamoDBTable()
-        mock_resource = MockDynamoDBResource(tenants_table, users_table)
+        mock_resource = MockDynamoDBResource(nations_table)
 
         # Upgrading to organization plan
         subscription_data = {
@@ -436,7 +427,7 @@ class TestSubscriptionUpdatedIntegration:
         assert response["statusCode"] == 200
 
         # Verify plan was upgraded
-        update = tenants_table.update_calls[0]
+        update = nations_table.update_calls[0]
         assert update["ExpressionAttributeValues"][":plan"] == "org"
         assert update["ExpressionAttributeValues"][":limit"] == PLAN_QUERY_LIMITS["org"]
 
@@ -445,16 +436,15 @@ class TestSubscriptionDeletedIntegration:
     """Integration tests for customer.subscription.deleted event."""
 
     def test_subscription_cancelled(self) -> None:
-        """Test that deleted subscription marks tenant as cancelled."""
-        tenants_table = MockDynamoDBTable([{
-            "tenant_id": TEST_TENANT_ID,
+        """Test that deleted subscription marks the nation as cancelled."""
+        nations_table = MockDynamoDBTable([{
+            "nation_slug": TEST_NATION_SLUG,
             "stripe_customer_id": TEST_CUSTOMER_ID,
-            "stripe_subscription_status": "active",
+            "subscription_status": "active",
         }])
-        tenants_table.query_results = [tenants_table._items[TEST_TENANT_ID]]
+        nations_table.query_results = [nations_table._items[TEST_NATION_SLUG]]
 
-        users_table = MockDynamoDBTable()
-        mock_resource = MockDynamoDBResource(tenants_table, users_table)
+        mock_resource = MockDynamoDBResource(nations_table)
 
         subscription_data = {
             "customer": TEST_CUSTOMER_ID,
@@ -484,8 +474,8 @@ class TestSubscriptionDeletedIntegration:
         assert response["statusCode"] == 200
 
         # Verify subscription status was updated to cancelled
-        assert len(tenants_table.update_calls) == 1
-        update = tenants_table.update_calls[0]
+        assert len(nations_table.update_calls) == 1
+        update = nations_table.update_calls[0]
         assert update["ExpressionAttributeValues"][":status"] == "cancelled"
 
 
@@ -494,13 +484,13 @@ class TestSignatureVerificationIntegration:
 
     def test_valid_signature_accepted(self) -> None:
         """Test that valid signatures are accepted."""
-        tenants_table = MockDynamoDBTable()
-        users_table = MockDynamoDBTable()
-        mock_resource = MockDynamoDBResource(tenants_table, users_table)
+        nations_table = MockDynamoDBTable()
+        mock_resource = MockDynamoDBResource(nations_table)
 
         event_payload = create_webhook_event("checkout.session.completed", {
             "customer": TEST_CUSTOMER_ID,
             "subscription": TEST_SUBSCRIPTION_ID,
+            "metadata": {"nation_slug": TEST_NATION_SLUG},
         })
         body = json.dumps(event_payload)
         signature = create_stripe_signature(body, TEST_WEBHOOK_SECRET)
@@ -595,13 +585,13 @@ class TestSignatureVerificationIntegration:
 
     def test_lowercase_header_accepted(self) -> None:
         """Test that lowercase stripe-signature header is accepted."""
-        tenants_table = MockDynamoDBTable()
-        users_table = MockDynamoDBTable()
-        mock_resource = MockDynamoDBResource(tenants_table, users_table)
+        nations_table = MockDynamoDBTable()
+        mock_resource = MockDynamoDBResource(nations_table)
 
         event_payload = create_webhook_event("checkout.session.completed", {
             "customer": TEST_CUSTOMER_ID,
             "subscription": TEST_SUBSCRIPTION_ID,
+            "metadata": {"nation_slug": TEST_NATION_SLUG},
         })
         body = json.dumps(event_payload)
         signature = create_stripe_signature(body, TEST_WEBHOOK_SECRET)

--- a/tests/test_nat_agent_streaming.py
+++ b/tests/test_nat_agent_streaming.py
@@ -233,11 +233,8 @@ class TestProcessStreamingRequest:
         assert "event: error" in events[0]
         assert "Missing required field: user_id" in events[0]
 
-    @patch("src.lambdas.nat_agent_streaming.handler.get_user_info")
-    def test_user_not_found(self, mock_get_user: MagicMock) -> None:
-        """Test that unknown user returns error event."""
-        mock_get_user.return_value = None
-
+    def test_missing_nation_slug(self) -> None:
+        """Test that a request without nation_slug returns an error event."""
         async def _test() -> list[str]:
             body = {"query": "test query", "user_id": TEST_USER_ID}
             events = []
@@ -248,18 +245,28 @@ class TestProcessStreamingRequest:
         events = run_async(_test())
         assert len(events) == 1
         assert "event: error" in events[0]
-        assert "USER_NOT_FOUND" in events[0]
+        assert "Missing required field: nation_slug" in events[0]
 
-    @patch("src.lambdas.nat_agent_streaming.handler.get_user_info")
-    def test_nb_not_connected(self, mock_get_user: MagicMock) -> None:
-        """Test that NB not connected returns error event."""
-        mock_get_user.return_value = {
-            "user_id": TEST_USER_ID,
-            "nb_connected": False,
-        }
+    @patch("src.lambdas.nat_agent_streaming.handler.check_rate_limit")
+    @patch("src.lambdas.nat_agent_streaming.handler.check_and_reset_billing_cycle_nation")
+    @patch("src.lambdas.nat_agent_streaming.handler.get_nb_tokens_by_nation")
+    def test_nb_not_connected(
+        self,
+        mock_get_tokens: MagicMock,
+        mock_billing: MagicMock,
+        mock_rate_limit: MagicMock,
+    ) -> None:
+        """Test that a nation without NB tokens returns NB_NOT_CONNECTED."""
+        mock_get_tokens.return_value = None
+        mock_billing.return_value = False
+        mock_rate_limit.return_value = None
 
         async def _test() -> list[str]:
-            body = {"query": "test query", "user_id": TEST_USER_ID}
+            body = {
+                "query": "test query",
+                "user_id": TEST_USER_ID,
+                "nation_slug": TEST_NB_SLUG,
+            }
             events = []
             async for event in process_streaming_request(body):
                 events.append(event)
@@ -269,49 +276,28 @@ class TestProcessStreamingRequest:
         assert len(events) == 1
         assert "event: error" in events[0]
         assert "NB_NOT_CONNECTED" in events[0]
-
-    @patch("src.lambdas.nat_agent_streaming.handler.get_user_info")
-    def test_nb_needs_reauth(self, mock_get_user: MagicMock) -> None:
-        """Test that NB needs reauth returns error event."""
-        mock_get_user.return_value = {
-            "user_id": TEST_USER_ID,
-            "nb_connected": True,
-            "nb_needs_reauth": True,
-        }
-
-        async def _test() -> list[str]:
-            body = {"query": "test query", "user_id": TEST_USER_ID}
-            events = []
-            async for event in process_streaming_request(body):
-                events.append(event)
-            return events
-
-        events = run_async(_test())
-        assert len(events) == 1
-        assert "event: error" in events[0]
-        assert "NB_NEEDS_REAUTH" in events[0]
+        mock_billing.assert_called_once_with(TEST_NB_SLUG)
 
     @patch("src.lambdas.nat_agent_streaming.handler.check_rate_limit")
-    @patch("src.lambdas.nat_agent_streaming.handler.check_and_reset_billing_cycle")
-    @patch("src.lambdas.nat_agent_streaming.handler.get_nb_tokens")
-    @patch("src.lambdas.nat_agent_streaming.handler.get_user_info")
-    def test_nb_tokens_missing(
-        self, mock_get_user: MagicMock, mock_get_tokens: MagicMock,
-        mock_billing: MagicMock, mock_rate_limit: MagicMock
+    @patch("src.lambdas.nat_agent_streaming.handler.check_and_reset_billing_cycle_nation")
+    def test_rate_limit_exceeded(
+        self, mock_billing: MagicMock, mock_rate_limit: MagicMock
     ) -> None:
-        """Test that missing NB tokens returns error event."""
-        mock_get_user.return_value = {
-            "user_id": TEST_USER_ID,
-            "tenant_id": TEST_TENANT_ID,
-            "nb_connected": True,
-            "nb_needs_reauth": False,
-        }
-        mock_get_tokens.return_value = None
-        mock_billing.return_value = None
-        mock_rate_limit.return_value = None
+        """Test that exceeding the per-user rate limit returns an error event."""
+        from src.lambdas.shared.usage_tracking import RateLimitError
+
+        mock_billing.return_value = False
+        mock_rate_limit.side_effect = RateLimitError(
+            message="Rate limit exceeded. Please wait 3 seconds.",
+            retry_after=3,
+        )
 
         async def _test() -> list[str]:
-            body = {"query": "test query", "user_id": TEST_USER_ID}
+            body = {
+                "query": "test query",
+                "user_id": TEST_USER_ID,
+                "nation_slug": TEST_NB_SLUG,
+            }
             events = []
             async for event in process_streaming_request(body):
                 events.append(event)
@@ -320,7 +306,49 @@ class TestProcessStreamingRequest:
         events = run_async(_test())
         assert len(events) == 1
         assert "event: error" in events[0]
-        assert "NB_TOKENS_MISSING" in events[0]
+        assert "RATE_LIMIT_EXCEEDED" in events[0]
+
+    @patch("src.lambdas.nat_agent_streaming.handler.track_query_usage_nation")
+    @patch("src.lambdas.nat_agent_streaming.handler.stream_agent_response")
+    @patch("src.lambdas.nat_agent_streaming.handler.get_nb_tokens_by_nation")
+    @patch("src.lambdas.nat_agent_streaming.handler.check_rate_limit")
+    @patch("src.lambdas.nat_agent_streaming.handler.check_and_reset_billing_cycle_nation")
+    def test_successful_streaming_tracks_usage(
+        self,
+        mock_billing: MagicMock,
+        mock_rate_limit: MagicMock,
+        mock_get_tokens: MagicMock,
+        mock_stream: MagicMock,
+        mock_track: MagicMock,
+    ) -> None:
+        """Test that a successful stream increments per-nation usage."""
+        mock_billing.return_value = False
+        mock_rate_limit.return_value = None
+        mock_get_tokens.return_value = (TEST_NB_TOKEN, TEST_NB_SLUG)
+        mock_track.return_value = 42
+
+        async def fake_stream(**kwargs: Any) -> Any:
+            yield format_sse_event(
+                SSE_EVENT_DONE, {"response": "hi", "tool_calls": []}
+            )
+
+        mock_stream.side_effect = lambda **kwargs: fake_stream(**kwargs)
+
+        async def _test() -> list[str]:
+            body = {
+                "query": "test query",
+                "user_id": TEST_USER_ID,
+                "nation_slug": TEST_NB_SLUG,
+            }
+            events = []
+            async for event in process_streaming_request(body):
+                events.append(event)
+            return events
+
+        events = run_async(_test())
+        assert any("event: done" in event for event in events)
+        # Usage is charged to the nation, keyed by the requesting user
+        mock_track.assert_called_once_with(TEST_USER_ID, TEST_NB_SLUG)
 
 
 class TestHandler:

--- a/tests/test_nb_oauth_callback.py
+++ b/tests/test_nb_oauth_callback.py
@@ -42,11 +42,28 @@ def create_state(user_id: str, nb_slug: str, redirect_uri: str) -> str:
 
 
 class MockDynamoDBTable:
-    """Mock DynamoDB table for testing."""
+    """Mock DynamoDB table for testing (per-nation model)."""
 
     def __init__(self) -> None:
         self.items: dict[str, dict[str, Any]] = {}
+        self.put_calls: list[dict[str, Any]] = []
         self.update_calls: list[dict[str, Any]] = []
+
+    @staticmethod
+    def _key(data: dict[str, Any]) -> Any:
+        return data.get("nation_slug") or data.get("user_id")
+
+    def get_item(self, Key: dict[str, Any]) -> dict[str, Any]:
+        key = self._key(Key)
+        if key is not None and key in self.items:
+            return {"Item": self.items[key]}
+        return {}
+
+    def put_item(self, Item: dict[str, Any]) -> None:
+        key = self._key(Item)
+        if key:
+            self.items[key] = Item
+        self.put_calls.append(Item)
 
     def update_item(
         self,
@@ -62,12 +79,25 @@ class MockDynamoDBTable:
 
 
 class MockDynamoDBResource:
-    """Mock DynamoDB resource for testing."""
+    """Mock DynamoDB resource for testing.
 
-    def __init__(self, users_table: MockDynamoDBTable) -> None:
+    Routes by table name so the per-nation NationsTable and the UsersTable
+    operations land on distinct backing tables.
+    """
+
+    def __init__(
+        self,
+        users_table: MockDynamoDBTable,
+        nations_table: MockDynamoDBTable | None = None,
+    ) -> None:
         self.users_table = users_table
+        self.nations_table = (
+            nations_table if nations_table is not None else MockDynamoDBTable()
+        )
 
     def Table(self, name: str) -> MockDynamoDBTable:
+        if "nation" in name.lower():
+            return self.nations_table
         return self.users_table
 
 
@@ -128,25 +158,24 @@ class TestStoreNBTokens:
     def test_updates_existing_secret(self) -> None:
         """Test that existing secret is updated."""
         mock_client = MockSecretsManagerClient()
-        mock_client.secrets[f"nat/user/{TEST_USER_ID}/nb-tokens"] = "{}"
+        mock_client.secrets[f"nat/nation/{TEST_NB_SLUG}/nb-tokens"] = "{}"
 
         with patch(
             "src.lambdas.nb_oauth_callback.handler.get_secrets_manager_client",
             return_value=mock_client,
         ):
             store_nb_tokens(
-                user_id=TEST_USER_ID,
+                nation_slug=TEST_NB_SLUG,
                 access_token=TEST_ACCESS_TOKEN,
                 refresh_token=TEST_REFRESH_TOKEN,
                 expires_in=7200,
-                nb_slug=TEST_NB_SLUG,
             )
 
         assert len(mock_client.put_calls) == 1
         secret_data = json.loads(mock_client.put_calls[0]["SecretString"])
         assert secret_data["access_token"] == TEST_ACCESS_TOKEN
         assert secret_data["refresh_token"] == TEST_REFRESH_TOKEN
-        assert secret_data["nb_slug"] == TEST_NB_SLUG
+        assert secret_data["nation_slug"] == TEST_NB_SLUG
         assert "expires_at" in secret_data
 
     def test_creates_new_secret_if_not_exists(self) -> None:
@@ -170,15 +199,14 @@ class TestStoreNBTokens:
             return_value=mock_client,
         ):
             store_nb_tokens(
-                user_id=TEST_USER_ID,
+                nation_slug=TEST_NB_SLUG,
                 access_token=TEST_ACCESS_TOKEN,
                 refresh_token=TEST_REFRESH_TOKEN,
                 expires_in=7200,
-                nb_slug=TEST_NB_SLUG,
             )
 
         assert len(mock_client.create_calls) == 1
-        assert mock_client.create_calls[0]["Name"] == f"nat/user/{TEST_USER_ID}/nb-tokens"
+        assert mock_client.create_calls[0]["Name"] == f"nat/nation/{TEST_NB_SLUG}/nb-tokens"
 
 
 class TestUpdateUserNBStatus:
@@ -320,11 +348,12 @@ class TestHandler:
     def test_successful_oauth_flow(self) -> None:
         """Test successful OAuth flow end-to-end."""
         users_table = MockDynamoDBTable()
-        mock_resource = MockDynamoDBResource(users_table)
+        nations_table = MockDynamoDBTable()
+        mock_resource = MockDynamoDBResource(users_table, nations_table)
         mock_sm_client = MockSecretsManagerClient()
         mock_sm_client.secrets["nat/nb-client-id"] = TEST_CLIENT_ID
         mock_sm_client.secrets["nat/nb-client-secret"] = TEST_CLIENT_SECRET
-        mock_sm_client.secrets[f"nat/user/{TEST_USER_ID}/nb-tokens"] = "{}"
+        mock_sm_client.secrets[f"nat/nation/{TEST_NB_SLUG}/nb-tokens"] = "{}"
 
         mock_token_response = MockHTTPResponse(
             status=200,
@@ -367,8 +396,14 @@ class TestHandler:
         assert "connected" in response["headers"]["Location"].lower()
         assert TEST_USER_ID in response["headers"]["Location"]
 
-        # Verify user was updated
-        assert len(users_table.update_calls) == 1
+        # Verify nation connection record was created/updated
+        assert len(nations_table.put_calls) == 1
+        assert nations_table.put_calls[0]["nation_slug"] == TEST_NB_SLUG
+        assert nations_table.put_calls[0]["nb_connected"] is True
+
+        # Verify user was linked to the nation
+        assert len(users_table.put_calls) == 1
+        assert users_table.put_calls[0]["nation_slug"] == TEST_NB_SLUG
 
     def test_token_exchange_failure_redirects_to_error(self) -> None:
         """Test that token exchange failure redirects to error page."""

--- a/tests/test_stripe_checkout.py
+++ b/tests/test_stripe_checkout.py
@@ -22,6 +22,7 @@ from src.lambdas.stripe_checkout.handler import (
 TEST_STRIPE_SECRET_KEY = "sk_test_12345"
 TEST_SESSION_ID = "cs_test_session_123"
 TEST_CHECKOUT_URL = "https://checkout.stripe.com/pay/cs_test_session_123"
+TEST_NATION_SLUG = "testnation"
 
 
 class TestGetStripeSecretKey:
@@ -84,7 +85,7 @@ class TestCreateCheckoutSession:
                 }).encode("utf-8"),
             )
 
-            result = create_checkout_session("starter", TEST_STRIPE_SECRET_KEY)
+            result = create_checkout_session("starter", TEST_NATION_SLUG, TEST_STRIPE_SECRET_KEY)
 
             assert result["id"] == TEST_SESSION_ID
             assert result["url"] == TEST_CHECKOUT_URL
@@ -110,7 +111,7 @@ class TestCreateCheckoutSession:
                 }).encode("utf-8"),
             )
 
-            result = create_checkout_session("team", TEST_STRIPE_SECRET_KEY)
+            result = create_checkout_session("team", TEST_NATION_SLUG, TEST_STRIPE_SECRET_KEY)
             assert result["id"] == TEST_SESSION_ID
 
     def test_create_session_organization_plan(self) -> None:
@@ -127,13 +128,13 @@ class TestCreateCheckoutSession:
                 }).encode("utf-8"),
             )
 
-            result = create_checkout_session("organization", TEST_STRIPE_SECRET_KEY)
+            result = create_checkout_session("organization", TEST_NATION_SLUG, TEST_STRIPE_SECRET_KEY)
             assert result["id"] == TEST_SESSION_ID
 
     def test_create_session_invalid_plan(self) -> None:
         """Test that invalid plan raises ValueError."""
         with pytest.raises(ValueError, match="Invalid plan"):
-            create_checkout_session("invalid_plan", TEST_STRIPE_SECRET_KEY)
+            create_checkout_session("invalid_plan", TEST_NATION_SLUG, TEST_STRIPE_SECRET_KEY)
 
     def test_create_session_stripe_error(self) -> None:
         """Test handling Stripe API errors."""
@@ -152,7 +153,7 @@ class TestCreateCheckoutSession:
             )
 
             with pytest.raises(RuntimeError, match="Invalid price ID"):
-                create_checkout_session("starter", TEST_STRIPE_SECRET_KEY)
+                create_checkout_session("starter", TEST_NATION_SLUG, TEST_STRIPE_SECRET_KEY)
 
 
 class TestHandler:
@@ -172,7 +173,7 @@ class TestHandler:
 
         event: dict[str, Any] = {
             "httpMethod": "POST",
-            "body": json.dumps({"plan": "starter"}),
+            "body": json.dumps({"plan": "starter", "nation_slug": TEST_NATION_SLUG}),
         }
 
         response = handler(event, None)
@@ -196,7 +197,7 @@ class TestHandler:
 
         event: dict[str, Any] = {
             "httpMethod": "POST",
-            "body": json.dumps({"plan": "team"}),
+            "body": json.dumps({"plan": "team", "nation_slug": TEST_NATION_SLUG}),
         }
 
         response = handler(event, None)
@@ -219,7 +220,7 @@ class TestHandler:
 
         event: dict[str, Any] = {
             "httpMethod": "POST",
-            "body": json.dumps({"plan": "organization"}),
+            "body": json.dumps({"plan": "organization", "nation_slug": TEST_NATION_SLUG}),
         }
 
         response = handler(event, None)
@@ -240,13 +241,15 @@ class TestHandler:
 
         event: dict[str, Any] = {
             "httpMethod": "POST",
-            "body": json.dumps({"plan": "STARTER"}),
+            "body": json.dumps({"plan": "STARTER", "nation_slug": TEST_NATION_SLUG}),
         }
 
         response = handler(event, None)
 
         assert response["statusCode"] == 200
-        mock_create_session.assert_called_once_with("starter", TEST_STRIPE_SECRET_KEY)
+        mock_create_session.assert_called_once_with(
+            "starter", TEST_NATION_SLUG, TEST_STRIPE_SECRET_KEY
+        )
 
     def test_options_preflight(self) -> None:
         """Test OPTIONS preflight request handling."""
@@ -277,7 +280,7 @@ class TestHandler:
         """Test error when plan is invalid."""
         event: dict[str, Any] = {
             "httpMethod": "POST",
-            "body": json.dumps({"plan": "enterprise"}),
+            "body": json.dumps({"plan": "enterprise", "nation_slug": TEST_NATION_SLUG}),
         }
 
         response = handler(event, None)
@@ -324,7 +327,7 @@ class TestHandler:
 
         event: dict[str, Any] = {
             "httpMethod": "POST",
-            "body": json.dumps({"plan": "starter"}),
+            "body": json.dumps({"plan": "starter", "nation_slug": TEST_NATION_SLUG}),
         }
 
         response = handler(event, None)
@@ -344,7 +347,7 @@ class TestHandler:
 
         event: dict[str, Any] = {
             "httpMethod": "POST",
-            "body": json.dumps({"plan": "starter"}),
+            "body": json.dumps({"plan": "starter", "nation_slug": TEST_NATION_SLUG}),
         }
 
         response = handler(event, None)

--- a/tests/test_stripe_webhook.py
+++ b/tests/test_stripe_webhook.py
@@ -29,6 +29,7 @@ TEST_WEBHOOK_SECRET = "whsec_test_secret_12345"
 TEST_CUSTOMER_ID = "cus_test123"
 TEST_SUBSCRIPTION_ID = "sub_test456"
 TEST_EMAIL = "test@example.com"
+TEST_NATION_SLUG = "testnation"
 
 
 def create_stripe_signature(payload: str, secret: str, timestamp: int | None = None) -> str:
@@ -98,13 +99,13 @@ class TestGetPlanFromPrice:
         assert get_plan_from_price("prod_team_plan_abc") == "team"
         assert get_plan_from_price("price_org_enterprise") == "org"
 
-    def test_unknown_defaults_to_starter(self) -> None:
-        """Test that unknown price IDs default to starter."""
-        assert get_plan_from_price("price_unknown_xyz") == "starter"
+    def test_unknown_defaults_to_nat(self) -> None:
+        """Test that unknown price IDs default to nat (the basic plan)."""
+        assert get_plan_from_price("price_unknown_xyz") == "nat"
 
 
 class MockDynamoDBTable:
-    """Mock DynamoDB table for testing."""
+    """Mock DynamoDB table for testing (per-nation model)."""
 
     def __init__(self) -> None:
         self.items: dict[str, dict[str, Any]] = {}
@@ -112,11 +113,21 @@ class MockDynamoDBTable:
         self.update_calls: list[dict[str, Any]] = []
         self.query_results: list[dict[str, Any]] = []
 
+    @staticmethod
+    def _key(data: dict[str, Any]) -> Any:
+        return data.get("nation_slug") or data.get("tenant_id") or data.get("user_id")
+
     def put_item(self, Item: dict[str, Any]) -> None:
-        key = Item.get("tenant_id") or Item.get("user_id")
+        key = self._key(Item)
         if key:
             self.items[key] = Item
         self.put_calls.append(Item)
+
+    def get_item(self, Key: dict[str, Any]) -> dict[str, Any]:
+        key = self._key(Key)
+        if key is not None and key in self.items:
+            return {"Item": self.items[key]}
+        return {}
 
     def update_item(
         self,
@@ -141,32 +152,32 @@ class MockDynamoDBTable:
 
 
 class MockDynamoDBResource:
-    """Mock DynamoDB resource for testing."""
+    """Mock DynamoDB resource for testing.
 
-    def __init__(self, tenants_table: MockDynamoDBTable, users_table: MockDynamoDBTable) -> None:
-        self.tenants_table = tenants_table
-        self.users_table = users_table
+    The webhook handler now operates exclusively on the NationsTable, so a
+    single backing table is sufficient regardless of the table name requested.
+    """
+
+    def __init__(self, nations_table: MockDynamoDBTable) -> None:
+        self.nations_table = nations_table
 
     def Table(self, name: str) -> MockDynamoDBTable:
-        if "tenant" in name.lower():
-            return self.tenants_table
-        return self.users_table
+        return self.nations_table
 
 
 class TestHandleCheckoutCompleted:
     """Tests for checkout.session.completed event handling."""
 
-    def test_creates_tenant_and_user(self) -> None:
-        """Test that checkout creates new tenant and user."""
-        tenants_table = MockDynamoDBTable()
-        users_table = MockDynamoDBTable()
-        mock_resource = MockDynamoDBResource(tenants_table, users_table)
+    def test_creates_nation(self) -> None:
+        """Test that checkout creates a new nation record."""
+        nations_table = MockDynamoDBTable()
+        mock_resource = MockDynamoDBResource(nations_table)
 
         session = {
             "customer": TEST_CUSTOMER_ID,
             "subscription": TEST_SUBSCRIPTION_ID,
             "customer_email": TEST_EMAIL,
-            "metadata": {"plan": "team"},
+            "metadata": {"plan": "nat", "nation_slug": TEST_NATION_SLUG},
         }
 
         with patch(
@@ -175,33 +186,28 @@ class TestHandleCheckoutCompleted:
         ):
             handle_checkout_completed(session)
 
-        # Verify tenant created
-        assert len(tenants_table.put_calls) == 1
-        tenant = tenants_table.put_calls[0]
-        assert tenant["stripe_customer_id"] == TEST_CUSTOMER_ID
-        assert tenant["stripe_subscription_id"] == TEST_SUBSCRIPTION_ID
-        assert tenant["plan"] == "team"
-        assert tenant["queries_limit"] == PLAN_QUERY_LIMITS["team"]
-        assert tenant["queries_this_month"] == 0
+        # Verify nation created (new nations start in a trial state until the
+        # subscription.updated webhook confirms the paid plan).
+        assert len(nations_table.put_calls) == 1
+        nation = nations_table.put_calls[0]
+        assert nation["nation_slug"] == TEST_NATION_SLUG
+        assert nation["stripe_customer_id"] == TEST_CUSTOMER_ID
+        assert nation["stripe_subscription_id"] == TEST_SUBSCRIPTION_ID
+        assert nation["subscription_status"] == "trialing"
+        assert nation["admin_email"] == TEST_EMAIL
+        assert nation["queries_used_this_period"] == 0
 
-        # Verify user created
-        assert len(users_table.put_calls) == 1
-        user = users_table.put_calls[0]
-        assert user["email"] == TEST_EMAIL
-        assert user["role"] == "admin"
-        assert user["nb_connected"] is False
-
-    def test_existing_tenant_not_duplicated(self) -> None:
-        """Test that existing tenant is not duplicated."""
-        tenants_table = MockDynamoDBTable()
-        tenants_table.query_results = [{"tenant_id": "existing-tenant-id"}]
-        users_table = MockDynamoDBTable()
-        mock_resource = MockDynamoDBResource(tenants_table, users_table)
+    def test_existing_nation_updated_not_duplicated(self) -> None:
+        """Test that an existing nation is updated rather than duplicated."""
+        nations_table = MockDynamoDBTable()
+        nations_table.items[TEST_NATION_SLUG] = {"nation_slug": TEST_NATION_SLUG}
+        mock_resource = MockDynamoDBResource(nations_table)
 
         session = {
             "customer": TEST_CUSTOMER_ID,
             "subscription": TEST_SUBSCRIPTION_ID,
             "customer_email": TEST_EMAIL,
+            "metadata": {"plan": "nat", "nation_slug": TEST_NATION_SLUG},
         }
 
         with patch(
@@ -210,14 +216,33 @@ class TestHandleCheckoutCompleted:
         ):
             handle_checkout_completed(session)
 
-        # Should not create new tenant
-        assert len(tenants_table.put_calls) == 0
+        # Should update the existing nation, not create a new one
+        assert len(nations_table.put_calls) == 0
+        assert len(nations_table.update_calls) == 1
+
+    def test_missing_nation_slug_raises(self) -> None:
+        """Test that a checkout without nation_slug metadata raises."""
+        nations_table = MockDynamoDBTable()
+        mock_resource = MockDynamoDBResource(nations_table)
+
+        session = {
+            "customer": TEST_CUSTOMER_ID,
+            "subscription": TEST_SUBSCRIPTION_ID,
+            "customer_email": TEST_EMAIL,
+            "metadata": {"plan": "nat"},
+        }
+
+        with patch(
+            "src.lambdas.stripe_webhook.handler.get_dynamodb_resource",
+            return_value=mock_resource,
+        ):
+            with pytest.raises(ValueError, match="nation_slug"):
+                handle_checkout_completed(session)
 
     def test_no_customer_id_returns_early(self) -> None:
         """Test that missing customer ID is handled gracefully."""
-        tenants_table = MockDynamoDBTable()
-        users_table = MockDynamoDBTable()
-        mock_resource = MockDynamoDBResource(tenants_table, users_table)
+        nations_table = MockDynamoDBTable()
+        mock_resource = MockDynamoDBResource(nations_table)
 
         session = {"subscription": TEST_SUBSCRIPTION_ID}
 
@@ -227,7 +252,7 @@ class TestHandleCheckoutCompleted:
         ):
             handle_checkout_completed(session)
 
-        assert len(tenants_table.put_calls) == 0
+        assert len(nations_table.put_calls) == 0
 
 
 class TestHandleSubscriptionUpdated:
@@ -235,10 +260,11 @@ class TestHandleSubscriptionUpdated:
 
     def test_updates_subscription_status(self) -> None:
         """Test that subscription status is updated."""
-        tenants_table = MockDynamoDBTable()
-        tenants_table.query_results = [{"tenant_id": "test-tenant-id", "billing_cycle_start": "2025-01-01"}]
-        users_table = MockDynamoDBTable()
-        mock_resource = MockDynamoDBResource(tenants_table, users_table)
+        nations_table = MockDynamoDBTable()
+        nations_table.query_results = [
+            {"nation_slug": TEST_NATION_SLUG, "billing_period_start": "2025-01-01"}
+        ]
+        mock_resource = MockDynamoDBResource(nations_table)
 
         subscription = {
             "customer": TEST_CUSTOMER_ID,
@@ -255,19 +281,20 @@ class TestHandleSubscriptionUpdated:
         ):
             handle_subscription_updated(subscription)
 
-        assert len(tenants_table.update_calls) == 1
-        update = tenants_table.update_calls[0]
-        assert update["Key"] == {"tenant_id": "test-tenant-id"}
+        assert len(nations_table.update_calls) == 1
+        update = nations_table.update_calls[0]
+        assert update["Key"] == {"nation_slug": TEST_NATION_SLUG}
         assert update["ExpressionAttributeValues"][":status"] == "active"
         assert update["ExpressionAttributeValues"][":plan"] == "team"
         assert update["ExpressionAttributeValues"][":limit"] == PLAN_QUERY_LIMITS["team"]
 
     def test_resets_usage_on_new_billing_cycle(self) -> None:
         """Test that query usage is reset when billing cycle changes."""
-        tenants_table = MockDynamoDBTable()
-        tenants_table.query_results = [{"tenant_id": "test-tenant-id", "billing_cycle_start": "2025-01-01"}]
-        users_table = MockDynamoDBTable()
-        mock_resource = MockDynamoDBResource(tenants_table, users_table)
+        nations_table = MockDynamoDBTable()
+        nations_table.query_results = [
+            {"nation_slug": TEST_NATION_SLUG, "billing_period_start": "2025-01-01"}
+        ]
+        mock_resource = MockDynamoDBResource(nations_table)
 
         # New billing cycle (February)
         new_period_start = 1738368000  # 2025-02-01
@@ -286,17 +313,17 @@ class TestHandleSubscriptionUpdated:
         ):
             handle_subscription_updated(subscription)
 
-        update = tenants_table.update_calls[0]
+        update = nations_table.update_calls[0]
         assert ":zero" in update["ExpressionAttributeValues"]
         assert update["ExpressionAttributeValues"][":zero"] == 0
-        assert "billing_cycle_start" in update["UpdateExpression"]
+        assert "billing_period_start" in update["UpdateExpression"]
+        assert "queries_used_this_period" in update["UpdateExpression"]
 
-    def test_no_tenant_found(self) -> None:
-        """Test that missing tenant is handled gracefully."""
-        tenants_table = MockDynamoDBTable()
-        tenants_table.query_results = []
-        users_table = MockDynamoDBTable()
-        mock_resource = MockDynamoDBResource(tenants_table, users_table)
+    def test_no_nation_found(self) -> None:
+        """Test that a missing nation is handled gracefully."""
+        nations_table = MockDynamoDBTable()
+        nations_table.query_results = []
+        mock_resource = MockDynamoDBResource(nations_table)
 
         subscription = {
             "customer": TEST_CUSTOMER_ID,
@@ -310,7 +337,7 @@ class TestHandleSubscriptionUpdated:
         ):
             handle_subscription_updated(subscription)
 
-        assert len(tenants_table.update_calls) == 0
+        assert len(nations_table.update_calls) == 0
 
 
 class TestHandleSubscriptionDeleted:
@@ -318,10 +345,9 @@ class TestHandleSubscriptionDeleted:
 
     def test_marks_subscription_cancelled(self) -> None:
         """Test that subscription is marked as cancelled."""
-        tenants_table = MockDynamoDBTable()
-        tenants_table.query_results = [{"tenant_id": "test-tenant-id"}]
-        users_table = MockDynamoDBTable()
-        mock_resource = MockDynamoDBResource(tenants_table, users_table)
+        nations_table = MockDynamoDBTable()
+        nations_table.query_results = [{"nation_slug": TEST_NATION_SLUG}]
+        mock_resource = MockDynamoDBResource(nations_table)
 
         subscription = {
             "customer": TEST_CUSTOMER_ID,
@@ -334,8 +360,8 @@ class TestHandleSubscriptionDeleted:
         ):
             handle_subscription_deleted(subscription)
 
-        assert len(tenants_table.update_calls) == 1
-        update = tenants_table.update_calls[0]
+        assert len(nations_table.update_calls) == 1
+        update = nations_table.update_calls[0]
         assert update["ExpressionAttributeValues"][":status"] == "cancelled"
 
 
@@ -344,9 +370,8 @@ class TestHandler:
 
     def test_valid_checkout_event(self) -> None:
         """Test successful processing of checkout event."""
-        tenants_table = MockDynamoDBTable()
-        users_table = MockDynamoDBTable()
-        mock_resource = MockDynamoDBResource(tenants_table, users_table)
+        nations_table = MockDynamoDBTable()
+        mock_resource = MockDynamoDBResource(nations_table)
 
         event_body = {
             "id": "evt_test",
@@ -356,6 +381,7 @@ class TestHandler:
                     "customer": TEST_CUSTOMER_ID,
                     "subscription": TEST_SUBSCRIPTION_ID,
                     "customer_email": TEST_EMAIL,
+                    "metadata": {"nation_slug": TEST_NATION_SLUG},
                 }
             },
         }
@@ -449,9 +475,8 @@ class TestHandler:
 
     def test_lowercase_signature_header(self) -> None:
         """Test that lowercase signature header is accepted."""
-        tenants_table = MockDynamoDBTable()
-        users_table = MockDynamoDBTable()
-        mock_resource = MockDynamoDBResource(tenants_table, users_table)
+        nations_table = MockDynamoDBTable()
+        mock_resource = MockDynamoDBResource(nations_table)
 
         event_body = {
             "type": "checkout.session.completed",
@@ -459,6 +484,7 @@ class TestHandler:
                 "object": {
                     "customer": TEST_CUSTOMER_ID,
                     "subscription": TEST_SUBSCRIPTION_ID,
+                    "metadata": {"nation_slug": TEST_NATION_SLUG},
                 }
             },
         }


### PR DESCRIPTION
Closes #6.

Updates the test suite to the **per-nation billing** signatures so CI is green again and deploys are unblocked. Production code is unchanged — this is a test-only diff (the migration had already changed the contracts; the tests were stale).

### Changes
Touches only the 6 previously-failing test files:
- `tests/test_stripe_checkout.py`, `tests/test_stripe_webhook.py`, `tests/integration/test_stripe_webhook_integration.py` — pass `nation_slug`, include it in Stripe metadata fixtures
- `tests/test_nb_oauth_callback.py`, `tests/integration/test_nb_oauth_integration.py` — `nat/nation/{slug}/nb-tokens` token paths
- `tests/test_nat_agent_streaming.py` — nation-based token lookup

### Verification (run locally on this branch)
- `python -m pytest -q` → **492 passed, 0 failed** (was 452 passed / 39 failed on `main`)
- `mypy src/ --explicit-package-bases` → **Success: no issues found in 21 source files**

### Reviewer note
This PR was produced by a `/pr-driver` run that **errored at the finalize/push step before its adversarial self-review completed** — so the branch had a clean local commit but was never pushed. I pushed it and verified the pytest + mypy evidence above independently. The diff is test-only and the contracts match the migrated handlers, but it has **not** been through pr-driver's self-review, so give it a normal independent pass via `/ship`.

Per-nation billing is the locked decision (see #18).
