### PR TITLE
fix(security): enforce nation subscription gate in agent handlers (fixes #9)

### DIFF
--- a/src/lambdas/nat_agent/handler.py
+++ b/src/lambdas/nat_agent/handler.py
@@ -22,6 +22,10 @@ from src.lambdas.shared.usage_tracking import (
     track_query_usage_nation,
     check_and_reset_billing_cycle_nation,
 )
+from src.lambdas.shared.subscription_middleware import (
+    SubscriptionError,
+    verify_nation_subscription,
+)
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -382,8 +386,28 @@ def handler(event: dict[str, Any], context: Any) -> LambdaResponse:
             f"Processing query for nation {nation_slug}, user {user_id}: {query[:100]}..."
         )
 
-        # Check if the nation's billing cycle has reset
+        # Check if the nation's billing cycle has reset (must run before the
+        # subscription limit check so queries_used reflects the current period).
         check_and_reset_billing_cycle_nation(nation_slug)
+
+        # Verify the nation's subscription before doing any work. This is the
+        # billing gate: cancelled / past-due / over-limit nations are blocked
+        # even when they still hold valid NB tokens.
+        try:
+            verify_nation_subscription(user_id, nation_slug)
+        except SubscriptionError as e:
+            logger.warning(
+                f"Nation subscription check failed for {nation_slug}: "
+                f"{e.code.value} - {e.message}"
+            )
+            return {
+                "statusCode": e.http_status,
+                "body": json.dumps({
+                    "error": e.message,
+                    "error_code": e.code.value,
+                }),
+                "headers": headers,
+            }
 
         # Check rate limit (5-second cooldown per user, anti-abuse)
         try:

--- a/src/lambdas/nat_agent_streaming/handler.py
+++ b/src/lambdas/nat_agent_streaming/handler.py
@@ -22,6 +22,10 @@ from src.lambdas.shared.usage_tracking import (
     track_query_usage_nation,
     check_and_reset_billing_cycle_nation,
 )
+from src.lambdas.shared.subscription_middleware import (
+    SubscriptionError,
+    verify_nation_subscription,
+)
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -482,8 +486,25 @@ async def process_streaming_request(body: dict[str, Any]) -> AsyncGenerator[str,
 
     logger.info(f"Processing streaming query for nation {nation_slug}, user {user_id}: {query[:100]}...")
 
-    # Check if billing cycle has reset for this nation
+    # Check if billing cycle has reset for this nation (must run before the
+    # subscription limit check so queries_used reflects the current period).
     check_and_reset_billing_cycle_nation(nation_slug)
+
+    # Verify the nation's subscription before doing any work. This is the
+    # billing gate: cancelled / past-due / over-limit nations are blocked
+    # even when they still hold valid NB tokens.
+    try:
+        verify_nation_subscription(user_id, nation_slug)
+    except SubscriptionError as e:
+        logger.warning(
+            f"Nation subscription check failed for {nation_slug}: "
+            f"{e.code.value} - {e.message}"
+        )
+        yield format_sse_event(SSE_EVENT_ERROR, {
+            "error": e.message,
+            "error_code": e.code.value,
+        })
+        return
 
     # Check rate limit (5-second cooldown per user, anti-abuse)
     try:

--- a/tests/test_nat_agent.py
+++ b/tests/test_nat_agent.py
@@ -322,6 +322,7 @@ class TestHandler:
         body = json.loads(response["body"])
         assert "nation_slug" in body["error"]
 
+    @patch("src.lambdas.nat_agent.handler.verify_nation_subscription")
     @patch("src.lambdas.nat_agent.handler.check_rate_limit")
     @patch("src.lambdas.nat_agent.handler.check_and_reset_billing_cycle_nation")
     @patch("src.lambdas.nat_agent.handler.get_nb_tokens_by_nation")
@@ -330,6 +331,7 @@ class TestHandler:
         mock_get_tokens: MagicMock,
         mock_billing: MagicMock,
         mock_rate: MagicMock,
+        mock_verify: MagicMock,
     ) -> None:
         """Test that a nation without NB tokens returns NB_NOT_CONNECTED."""
         mock_get_tokens.return_value = None
@@ -344,12 +346,14 @@ class TestHandler:
         mock_billing.assert_called_once_with(TEST_NATION_SLUG)
         mock_get_tokens.assert_called_once_with(TEST_NATION_SLUG)
 
+    @patch("src.lambdas.nat_agent.handler.verify_nation_subscription")
     @patch("src.lambdas.nat_agent.handler.check_and_reset_billing_cycle_nation")
     @patch("src.lambdas.nat_agent.handler.check_rate_limit")
     def test_rate_limit_exceeded(
         self,
         mock_rate: MagicMock,
         mock_billing: MagicMock,
+        mock_verify: MagicMock,
     ) -> None:
         """Test that exceeding the per-user rate limit returns 429."""
         from src.lambdas.shared.usage_tracking import RateLimitError
@@ -367,6 +371,7 @@ class TestHandler:
         assert body["error_code"] == "RATE_LIMIT_EXCEEDED"
         assert response["headers"]["Retry-After"] == "3"
 
+    @patch("src.lambdas.nat_agent.handler.verify_nation_subscription")
     @patch("src.lambdas.nat_agent.handler.track_query_usage_nation")
     @patch("src.lambdas.nat_agent.handler.check_rate_limit")
     @patch("src.lambdas.nat_agent.handler.check_and_reset_billing_cycle_nation")
@@ -379,6 +384,7 @@ class TestHandler:
         mock_billing: MagicMock,
         mock_rate: MagicMock,
         mock_track: MagicMock,
+        mock_verify: MagicMock,
     ) -> None:
         """Test successful agent query charges usage to the nation."""
         mock_get_tokens.return_value = (TEST_NB_TOKEN, TEST_NB_SLUG)
@@ -404,7 +410,10 @@ class TestHandler:
         assert len(body["tool_calls"]) == 1
         # Usage is charged to the nation, keyed by the requesting user
         mock_track.assert_called_once_with(TEST_USER_ID, TEST_NATION_SLUG)
+        # The subscription gate is checked for the nation before processing
+        mock_verify.assert_called_once_with(TEST_USER_ID, TEST_NATION_SLUG)
 
+    @patch("src.lambdas.nat_agent.handler.verify_nation_subscription")
     @patch("src.lambdas.nat_agent.handler.track_query_usage_nation")
     @patch("src.lambdas.nat_agent.handler.check_rate_limit")
     @patch("src.lambdas.nat_agent.handler.check_and_reset_billing_cycle_nation")
@@ -417,6 +426,7 @@ class TestHandler:
         mock_billing: MagicMock,
         mock_rate: MagicMock,
         mock_track: MagicMock,
+        mock_verify: MagicMock,
     ) -> None:
         """Test query with page context."""
         mock_get_tokens.return_value = (TEST_NB_TOKEN, TEST_NB_SLUG)
@@ -442,6 +452,7 @@ class TestHandler:
 
         assert response["statusCode"] == 200
 
+    @patch("src.lambdas.nat_agent.handler.verify_nation_subscription")
     @patch("src.lambdas.nat_agent.handler.track_query_usage_nation")
     @patch("src.lambdas.nat_agent.handler.check_rate_limit")
     @patch("src.lambdas.nat_agent.handler.check_and_reset_billing_cycle_nation")
@@ -454,6 +465,7 @@ class TestHandler:
         mock_billing: MagicMock,
         mock_rate: MagicMock,
         mock_track: MagicMock,
+        mock_verify: MagicMock,
     ) -> None:
         """Test agent error handling does not charge usage."""
         mock_get_tokens.return_value = (TEST_NB_TOKEN, TEST_NB_SLUG)
@@ -476,6 +488,7 @@ class TestHandler:
         # No usage should be charged when the agent fails
         mock_track.assert_not_called()
 
+    @patch("src.lambdas.nat_agent.handler.verify_nation_subscription")
     @patch("src.lambdas.nat_agent.handler.check_rate_limit")
     @patch("src.lambdas.nat_agent.handler.check_and_reset_billing_cycle_nation")
     @patch("src.lambdas.nat_agent.handler.get_nb_tokens_by_nation")
@@ -484,6 +497,7 @@ class TestHandler:
         mock_get_tokens: MagicMock,
         mock_billing: MagicMock,
         mock_rate: MagicMock,
+        mock_verify: MagicMock,
     ) -> None:
         """Test that user_id and nation_slug can be supplied via headers."""
         mock_get_tokens.return_value = None  # Stop after token lookup
@@ -504,6 +518,7 @@ class TestHandler:
         mock_get_tokens.assert_called_once_with(TEST_NATION_SLUG)
         mock_billing.assert_called_once_with(TEST_NATION_SLUG)
 
+    @patch("src.lambdas.nat_agent.handler.verify_nation_subscription")
     @patch("src.lambdas.nat_agent.handler.check_rate_limit")
     @patch("src.lambdas.nat_agent.handler.check_and_reset_billing_cycle_nation")
     @patch("src.lambdas.nat_agent.handler.get_nb_tokens_by_nation")
@@ -512,6 +527,7 @@ class TestHandler:
         mock_get_tokens: MagicMock,
         mock_billing: MagicMock,
         mock_rate: MagicMock,
+        mock_verify: MagicMock,
     ) -> None:
         """Test that lowercase headers are honored for user_id and nation_slug."""
         mock_get_tokens.return_value = None
@@ -527,6 +543,70 @@ class TestHandler:
 
         assert response["statusCode"] == 403
         mock_get_tokens.assert_called_once_with(TEST_NATION_SLUG)
+
+    @patch("src.lambdas.nat_agent.handler.get_nb_tokens_by_nation")
+    @patch("src.lambdas.nat_agent.handler.check_rate_limit")
+    @patch("src.lambdas.nat_agent.handler.verify_nation_subscription")
+    @patch("src.lambdas.nat_agent.handler.check_and_reset_billing_cycle_nation")
+    def test_inactive_subscription_returns_402(
+        self,
+        mock_billing: MagicMock,
+        mock_verify: MagicMock,
+        mock_rate: MagicMock,
+        mock_get_tokens: MagicMock,
+    ) -> None:
+        """A cancelled/past-due nation is blocked with 402 before any work."""
+        from src.lambdas.shared.subscription_middleware import (
+            SubscriptionError,
+            SubscriptionErrorCode,
+        )
+
+        mock_verify.side_effect = SubscriptionError(
+            code=SubscriptionErrorCode.SUBSCRIPTION_INACTIVE,
+            message="Nation subscription is not active (status: cancelled).",
+            http_status=402,
+        )
+
+        event = create_api_event(body=self._valid_body())
+        response = handler(event, None)
+
+        assert response["statusCode"] == 402
+        body = json.loads(response["body"])
+        assert body["error_code"] == "SUBSCRIPTION_INACTIVE"
+        # Gate runs before NB tokens / rate limit, so neither is reached
+        mock_get_tokens.assert_not_called()
+        mock_rate.assert_not_called()
+
+    @patch("src.lambdas.nat_agent.handler.get_nb_tokens_by_nation")
+    @patch("src.lambdas.nat_agent.handler.check_rate_limit")
+    @patch("src.lambdas.nat_agent.handler.verify_nation_subscription")
+    @patch("src.lambdas.nat_agent.handler.check_and_reset_billing_cycle_nation")
+    def test_query_limit_exceeded_returns_403(
+        self,
+        mock_billing: MagicMock,
+        mock_verify: MagicMock,
+        mock_rate: MagicMock,
+        mock_get_tokens: MagicMock,
+    ) -> None:
+        """A nation over its query cap is blocked with 403."""
+        from src.lambdas.shared.subscription_middleware import (
+            SubscriptionError,
+            SubscriptionErrorCode,
+        )
+
+        mock_verify.side_effect = SubscriptionError(
+            code=SubscriptionErrorCode.QUERY_LIMIT_EXCEEDED,
+            message="Monthly query limit of 500 exceeded.",
+            http_status=403,
+        )
+
+        event = create_api_event(body=self._valid_body())
+        response = handler(event, None)
+
+        assert response["statusCode"] == 403
+        body = json.loads(response["body"])
+        assert body["error_code"] == "QUERY_LIMIT_EXCEEDED"
+        mock_get_tokens.assert_not_called()
 
     def test_cors_headers_present(self) -> None:
         """Test that CORS headers advertise the nation slug header."""

--- a/tests/test_nat_agent_streaming.py
+++ b/tests/test_nat_agent_streaming.py
@@ -247,6 +247,7 @@ class TestProcessStreamingRequest:
         assert "event: error" in events[0]
         assert "Missing required field: nation_slug" in events[0]
 
+    @patch("src.lambdas.nat_agent_streaming.handler.verify_nation_subscription")
     @patch("src.lambdas.nat_agent_streaming.handler.check_rate_limit")
     @patch("src.lambdas.nat_agent_streaming.handler.check_and_reset_billing_cycle_nation")
     @patch("src.lambdas.nat_agent_streaming.handler.get_nb_tokens_by_nation")
@@ -255,11 +256,13 @@ class TestProcessStreamingRequest:
         mock_get_tokens: MagicMock,
         mock_billing: MagicMock,
         mock_rate_limit: MagicMock,
+        mock_verify: MagicMock,
     ) -> None:
         """Test that a nation without NB tokens returns NB_NOT_CONNECTED."""
         mock_get_tokens.return_value = None
         mock_billing.return_value = False
         mock_rate_limit.return_value = None
+        mock_verify.return_value = {"valid": True}
 
         async def _test() -> list[str]:
             body = {
@@ -278,15 +281,20 @@ class TestProcessStreamingRequest:
         assert "NB_NOT_CONNECTED" in events[0]
         mock_billing.assert_called_once_with(TEST_NB_SLUG)
 
+    @patch("src.lambdas.nat_agent_streaming.handler.verify_nation_subscription")
     @patch("src.lambdas.nat_agent_streaming.handler.check_rate_limit")
     @patch("src.lambdas.nat_agent_streaming.handler.check_and_reset_billing_cycle_nation")
     def test_rate_limit_exceeded(
-        self, mock_billing: MagicMock, mock_rate_limit: MagicMock
+        self,
+        mock_billing: MagicMock,
+        mock_rate_limit: MagicMock,
+        mock_verify: MagicMock,
     ) -> None:
         """Test that exceeding the per-user rate limit returns an error event."""
         from src.lambdas.shared.usage_tracking import RateLimitError
 
         mock_billing.return_value = False
+        mock_verify.return_value = {"valid": True}
         mock_rate_limit.side_effect = RateLimitError(
             message="Rate limit exceeded. Please wait 3 seconds.",
             retry_after=3,
@@ -308,6 +316,7 @@ class TestProcessStreamingRequest:
         assert "event: error" in events[0]
         assert "RATE_LIMIT_EXCEEDED" in events[0]
 
+    @patch("src.lambdas.nat_agent_streaming.handler.verify_nation_subscription")
     @patch("src.lambdas.nat_agent_streaming.handler.track_query_usage_nation")
     @patch("src.lambdas.nat_agent_streaming.handler.stream_agent_response")
     @patch("src.lambdas.nat_agent_streaming.handler.get_nb_tokens_by_nation")
@@ -320,10 +329,12 @@ class TestProcessStreamingRequest:
         mock_get_tokens: MagicMock,
         mock_stream: MagicMock,
         mock_track: MagicMock,
+        mock_verify: MagicMock,
     ) -> None:
         """Test that a successful stream increments per-nation usage."""
         mock_billing.return_value = False
         mock_rate_limit.return_value = None
+        mock_verify.return_value = {"valid": True}
         mock_get_tokens.return_value = (TEST_NB_TOKEN, TEST_NB_SLUG)
         mock_track.return_value = 42
 
@@ -349,6 +360,92 @@ class TestProcessStreamingRequest:
         assert any("event: done" in event for event in events)
         # Usage is charged to the nation, keyed by the requesting user
         mock_track.assert_called_once_with(TEST_USER_ID, TEST_NB_SLUG)
+        # The subscription gate must be checked for the nation before work
+        mock_verify.assert_called_once_with(TEST_USER_ID, TEST_NB_SLUG)
+
+    @patch("src.lambdas.nat_agent_streaming.handler.get_nb_tokens_by_nation")
+    @patch("src.lambdas.nat_agent_streaming.handler.check_rate_limit")
+    @patch("src.lambdas.nat_agent_streaming.handler.verify_nation_subscription")
+    @patch("src.lambdas.nat_agent_streaming.handler.check_and_reset_billing_cycle_nation")
+    def test_inactive_subscription_blocked(
+        self,
+        mock_billing: MagicMock,
+        mock_verify: MagicMock,
+        mock_rate_limit: MagicMock,
+        mock_get_tokens: MagicMock,
+    ) -> None:
+        """A cancelled/past-due nation is blocked even with valid NB tokens."""
+        from src.lambdas.shared.subscription_middleware import (
+            SubscriptionError,
+            SubscriptionErrorCode,
+        )
+
+        mock_billing.return_value = False
+        mock_verify.side_effect = SubscriptionError(
+            code=SubscriptionErrorCode.SUBSCRIPTION_INACTIVE,
+            message="Nation subscription is not active (status: cancelled).",
+            http_status=402,
+        )
+
+        async def _test() -> list[str]:
+            body = {
+                "query": "test query",
+                "user_id": TEST_USER_ID,
+                "nation_slug": TEST_NB_SLUG,
+            }
+            events = []
+            async for event in process_streaming_request(body):
+                events.append(event)
+            return events
+
+        events = run_async(_test())
+        assert len(events) == 1
+        assert "event: error" in events[0]
+        assert "SUBSCRIPTION_INACTIVE" in events[0]
+        # Gate runs before NB tokens / rate limit, so neither is reached
+        mock_get_tokens.assert_not_called()
+        mock_rate_limit.assert_not_called()
+
+    @patch("src.lambdas.nat_agent_streaming.handler.get_nb_tokens_by_nation")
+    @patch("src.lambdas.nat_agent_streaming.handler.check_rate_limit")
+    @patch("src.lambdas.nat_agent_streaming.handler.verify_nation_subscription")
+    @patch("src.lambdas.nat_agent_streaming.handler.check_and_reset_billing_cycle_nation")
+    def test_query_limit_exceeded_blocked(
+        self,
+        mock_billing: MagicMock,
+        mock_verify: MagicMock,
+        mock_rate_limit: MagicMock,
+        mock_get_tokens: MagicMock,
+    ) -> None:
+        """A nation over its query cap is blocked with QUERY_LIMIT_EXCEEDED."""
+        from src.lambdas.shared.subscription_middleware import (
+            SubscriptionError,
+            SubscriptionErrorCode,
+        )
+
+        mock_billing.return_value = False
+        mock_verify.side_effect = SubscriptionError(
+            code=SubscriptionErrorCode.QUERY_LIMIT_EXCEEDED,
+            message="Monthly query limit exceeded.",
+            http_status=403,
+        )
+
+        async def _test() -> list[str]:
+            body = {
+                "query": "test query",
+                "user_id": TEST_USER_ID,
+                "nation_slug": TEST_NB_SLUG,
+            }
+            events = []
+            async for event in process_streaming_request(body):
+                events.append(event)
+            return events
+
+        events = run_async(_test())
+        assert len(events) == 1
+        assert "event: error" in events[0]
+        assert "QUERY_LIMIT_EXCEEDED" in events[0]
+        mock_get_tokens.assert_not_called()
 
 
 class TestHandler:

--- a/tests/test_subscription_middleware.py
+++ b/tests/test_subscription_middleware.py
@@ -16,9 +16,12 @@ from src.lambdas.shared.subscription_middleware import (
     SubscriptionMiddleware,
     SubscriptionStatus,
     UserContext,
+    extract_nation_from_headers,
     extract_user_from_headers,
+    get_nation_subscription,
     get_tenant_subscription,
     get_user_tenant_id,
+    verify_nation_subscription,
     verify_subscription,
 )
 
@@ -26,7 +29,26 @@ from src.lambdas.shared.subscription_middleware import (
 # Test data
 TEST_USER_ID = "user_test123"
 TEST_TENANT_ID = "tenant_test456"
+TEST_NATION_SLUG = "testnation"
 TEST_EMAIL = "test@example.com"
+
+
+def create_mock_nation(
+    nation_slug: str = TEST_NATION_SLUG,
+    status: str = "active",
+    plan: str = "nat",
+    queries_used_this_period: int = 0,
+    queries_limit: int = 500,
+) -> dict[str, Any]:
+    """Create a mock nation record."""
+    return {
+        "nation_slug": nation_slug,
+        "stripe_customer_id": "cus_test123",
+        "subscription_status": status,
+        "subscription_plan": plan,
+        "queries_used_this_period": queries_used_this_period,
+        "queries_limit": queries_limit,
+    }
 
 
 def create_mock_user(
@@ -314,6 +336,161 @@ class TestVerifySubscription:
         assert result["valid"] is True
         # get_user_tenant_id should not be called
         mock_get_tenant.assert_called_once_with(TEST_TENANT_ID)
+
+
+class TestExtractNationFromHeaders:
+    """Tests for extracting nation identity from headers."""
+
+    def test_extracts_user_and_nation(self) -> None:
+        """Test that user ID and nation slug are extracted from headers."""
+        headers = {
+            "X-Nat-User-Id": TEST_USER_ID,
+            "X-Nat-Nation-Slug": TEST_NATION_SLUG,
+        }
+        result = extract_nation_from_headers(headers)
+        assert result.user_id == TEST_USER_ID
+        assert result.nation_slug == TEST_NATION_SLUG
+
+    def test_handles_lowercase_headers(self) -> None:
+        """Test that lowercase headers are handled (API Gateway behavior)."""
+        headers = {
+            "x-nat-user-id": TEST_USER_ID,
+            "x-nat-nation-slug": TEST_NATION_SLUG,
+        }
+        result = extract_nation_from_headers(headers)
+        assert result.user_id == TEST_USER_ID
+        assert result.nation_slug == TEST_NATION_SLUG
+
+    def test_missing_user_id_raises_error(self) -> None:
+        """Test that missing user ID raises 401 SubscriptionError."""
+        with pytest.raises(SubscriptionError) as exc_info:
+            extract_nation_from_headers({"X-Nat-Nation-Slug": TEST_NATION_SLUG})
+        assert exc_info.value.code == SubscriptionErrorCode.MISSING_USER_ID
+        assert exc_info.value.http_status == 401
+
+    def test_missing_nation_slug_raises_error(self) -> None:
+        """Test that missing nation slug raises 401 SubscriptionError."""
+        with pytest.raises(SubscriptionError) as exc_info:
+            extract_nation_from_headers({"X-Nat-User-Id": TEST_USER_ID})
+        assert exc_info.value.code == SubscriptionErrorCode.MISSING_NATION_SLUG
+        assert exc_info.value.http_status == 401
+
+
+class TestGetNationSubscription:
+    """Tests for looking up nation subscription."""
+
+    @patch("src.lambdas.shared.subscription_middleware.get_dynamodb_resource")
+    def test_returns_nation(self, mock_dynamodb: MagicMock) -> None:
+        """Test that nation record is returned."""
+        mock_table = MagicMock()
+        mock_table.get_item.return_value = {"Item": create_mock_nation()}
+        mock_dynamodb.return_value.Table.return_value = mock_table
+
+        result = get_nation_subscription(TEST_NATION_SLUG)
+        assert result["nation_slug"] == TEST_NATION_SLUG
+        assert result["subscription_status"] == "active"
+
+    @patch("src.lambdas.shared.subscription_middleware.get_dynamodb_resource")
+    def test_nation_not_found_raises_error(self, mock_dynamodb: MagicMock) -> None:
+        """Test that missing nation raises 404 SubscriptionError."""
+        mock_table = MagicMock()
+        mock_table.get_item.return_value = {}
+        mock_dynamodb.return_value.Table.return_value = mock_table
+
+        with pytest.raises(SubscriptionError) as exc_info:
+            get_nation_subscription("nonexistent_nation")
+        assert exc_info.value.code == SubscriptionErrorCode.NATION_NOT_FOUND
+        assert exc_info.value.http_status == 404
+
+
+class TestVerifyNationSubscription:
+    """Tests for per-nation subscription verification (the billing gate)."""
+
+    @patch("src.lambdas.shared.subscription_middleware.get_nation_subscription")
+    def test_active_nation_passes(self, mock_get_nation: MagicMock) -> None:
+        """Active nation within limits returns a valid status."""
+        mock_get_nation.return_value = create_mock_nation(status="active")
+
+        result = verify_nation_subscription(TEST_USER_ID, TEST_NATION_SLUG)
+
+        assert result["valid"] is True
+        assert result["nation_slug"] == TEST_NATION_SLUG
+        assert result["subscription_status"] == "active"
+
+    @patch("src.lambdas.shared.subscription_middleware.get_nation_subscription")
+    def test_trialing_nation_passes(self, mock_get_nation: MagicMock) -> None:
+        """Trialing nation within limits returns a valid status."""
+        mock_get_nation.return_value = create_mock_nation(status="trialing")
+
+        result = verify_nation_subscription(TEST_USER_ID, TEST_NATION_SLUG)
+
+        assert result["valid"] is True
+        assert result["subscription_status"] == "trialing"
+
+    @pytest.mark.parametrize("status", ["cancelled", "past_due", "unpaid", "none"])
+    @patch("src.lambdas.shared.subscription_middleware.get_nation_subscription")
+    def test_inactive_nation_returns_402(
+        self, mock_get_nation: MagicMock, status: str
+    ) -> None:
+        """Cancelled / past-due / unpaid / none nations are blocked with 402."""
+        mock_get_nation.return_value = create_mock_nation(status=status)
+
+        with pytest.raises(SubscriptionError) as exc_info:
+            verify_nation_subscription(TEST_USER_ID, TEST_NATION_SLUG)
+
+        assert exc_info.value.code == SubscriptionErrorCode.SUBSCRIPTION_INACTIVE
+        assert exc_info.value.http_status == 402
+
+    @patch("src.lambdas.shared.subscription_middleware.get_nation_subscription")
+    def test_query_limit_exceeded_returns_403(
+        self, mock_get_nation: MagicMock
+    ) -> None:
+        """An active nation at its query cap is blocked with 403."""
+        mock_get_nation.return_value = create_mock_nation(
+            status="active",
+            queries_used_this_period=500,
+            queries_limit=500,
+        )
+
+        with pytest.raises(SubscriptionError) as exc_info:
+            verify_nation_subscription(TEST_USER_ID, TEST_NATION_SLUG)
+
+        assert exc_info.value.code == SubscriptionErrorCode.QUERY_LIMIT_EXCEEDED
+        assert exc_info.value.http_status == 403
+
+    @patch("src.lambdas.shared.subscription_middleware.get_nation_subscription")
+    def test_query_limit_not_exceeded_passes(
+        self, mock_get_nation: MagicMock
+    ) -> None:
+        """An active nation under its query cap passes."""
+        mock_get_nation.return_value = create_mock_nation(
+            status="active",
+            queries_used_this_period=499,
+            queries_limit=500,
+        )
+
+        result = verify_nation_subscription(TEST_USER_ID, TEST_NATION_SLUG)
+
+        assert result["valid"] is True
+        assert result["queries_used_this_period"] == 499
+        assert result["queries_limit"] == 500
+
+    @patch("src.lambdas.shared.subscription_middleware.get_nation_subscription")
+    def test_unlimited_plan_skips_limit_check(
+        self, mock_get_nation: MagicMock
+    ) -> None:
+        """A queries_limit of 0 means unlimited (nat_pro) and skips the cap."""
+        mock_get_nation.return_value = create_mock_nation(
+            status="active",
+            plan="nat_pro",
+            queries_used_this_period=10_000,
+            queries_limit=0,
+        )
+
+        result = verify_nation_subscription(TEST_USER_ID, TEST_NATION_SLUG)
+
+        assert result["valid"] is True
+        assert result["plan"] == "nat_pro"
 
 
 class TestSubscriptionMiddleware:


### PR DESCRIPTION
Closes #9.

Turns on the **subscription gate** that was built but never called. Until now, both agent handlers only checked NB tokens, reset the billing cycle, and rate-limited — a cancelled / past-due / over-limit nation could keep querying as long as it had valid tokens. This defeated the billing model.

### Changes
Both handlers now call `verify_nation_subscription(user_id, nation_slug)` right after the billing-cycle reset and before token retrieval / rate limiting:
- **non-streaming** (`nat_agent`): HTTP **402** `SUBSCRIPTION_INACTIVE` / **403** `QUERY_LIMIT_EXCEEDED` with structured `error_code`
- **streaming** (`nat_agent_streaming`): SSE `error` event with the same codes (the path the extension consumes; both already mapped in `ErrorMessage.tsx`)
- Ordering is deliberate: billing-cycle reset runs first (zeroes usage on a new period), then the gate reads fresh — so an over-limit nation is correctly allowed once its period rolls over.

### Verification (local, branch is based on current main)
- `python -m pytest -q` → **514 passed, 0 failed** (+19 vs main): `verify_nation_subscription` across active/trialing/cancelled/past_due/unpaid/none/over-limit/unlimited, header extraction, and handler-level blocked (402/403) + allowed states in **both** handlers
- `mypy src/ --explicit-package-bases` → clean
- pr-driver adversarial review ran **mutation testing** — commenting out each gate call breaks the matching tests, proving they aren't tautological. I re-verified independently (514 green, no skips/xfails, +16 test fns, none removed).

### Residual (non-blocking, pre-existing)
- `NATION_NOT_FOUND` (404) isn't explicitly mapped in the extension → falls to the generic error message. Graceful. Candidate follow-up.
- This enforces *subscription status*; it does **not** add the caller↔nation membership check (the IDOR) — that's #10.

Phase 2 of the launch arc (#18).
