### PR TITLE
feat(security): login-based session-token auth + IDOR fix (fixes #10)

### DIFF
--- a/extension/e2e/fixtures.ts
+++ b/extension/e2e/fixtures.ts
@@ -103,9 +103,44 @@ export async function setAuthState(
   const backgroundPage = await getBackgroundPage(context, extensionId);
 
   await backgroundPage.evaluate(async (state) => {
-    await chrome.storage.local.set({ authState: state });
-    // Also send message to notify any listeners
-    chrome.runtime.sendMessage({ type: 'AUTH_STATE_CHANGED', authState: state });
+    // Persist the individual keys the background's getAuthState() actually
+    // reads. Authentication is now token-based: an authenticated state must
+    // carry an `authToken` (the session JWT) sent as `Authorization: Bearer`.
+    const TEST_SESSION_TOKEN = 'test.session.token';
+    if (state.isAuthenticated) {
+      await chrome.storage.local.set({
+        authToken: TEST_SESSION_TOKEN,
+        userId: state.userId ?? null,
+        tenantId: state.tenantId ?? null,
+        nationSlug: state.nationSlug ?? null,
+        nbConnected: !!state.nbConnected,
+        nbNeedsReauth: !!state.nbNeedsReauth,
+        subscriptionStatus: state.subscriptionStatus ?? null,
+      });
+    } else {
+      await chrome.storage.local.remove([
+        'authToken',
+        'userId',
+        'tenantId',
+        'nationSlug',
+        'nbConnected',
+        'nbNeedsReauth',
+        'subscriptionStatus',
+      ]);
+    }
+
+    // Build the auth-state shape the UI listens for and broadcast it so any
+    // mounted components update immediately (mirrors notifyAuthStateChanged).
+    const authState = {
+      isAuthenticated: !!state.isAuthenticated,
+      userId: state.userId ?? null,
+      tenantId: state.tenantId ?? null,
+      nationSlug: state.nationSlug ?? null,
+      nbConnected: !!state.nbConnected,
+      nbNeedsReauth: !!state.nbNeedsReauth,
+      subscriptionStatus: state.subscriptionStatus ?? null,
+    };
+    chrome.runtime.sendMessage({ type: 'AUTH_STATE_CHANGED', authState });
   }, authState);
 }
 
@@ -126,6 +161,26 @@ export async function setTutorialCompleted(
       await chrome.storage.local.remove('nat_tutorial_completed');
     }
   }, completed);
+}
+
+/**
+ * Read a value from the extension's chrome.storage.local (via the background
+ * service worker context). Useful for asserting that the token handoff and
+ * auth-failure clearing wrote the expected keys.
+ */
+export async function getStorageValue<T = unknown>(
+  context: BrowserContext,
+  extensionId: string,
+  key: string
+): Promise<T | undefined> {
+  const backgroundPage = await getBackgroundPage(context, extensionId);
+  return backgroundPage.evaluate(
+    (k) =>
+      new Promise((resolve) => {
+        chrome.storage.local.get([k], (result) => resolve(result[k]));
+      }),
+    key
+  ) as Promise<T | undefined>;
 }
 
 /**

--- a/extension/e2e/mocks/server.ts
+++ b/extension/e2e/mocks/server.ts
@@ -65,6 +65,22 @@ const mockPages: Record<string, string> = {
     </html>
   `,
 
+  // OAuth success / connected page. The backend redirects here after the
+  // NationBuilder connect flow, delivering the session token in the URL
+  // fragment. The oauth-callback content script reads it from the fragment.
+  '/connected': `
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <title>Connected - Nat</title>
+    </head>
+    <body>
+      <h1>NationBuilder connected</h1>
+      <p>You can return to NationBuilder and start using Nat.</p>
+    </body>
+    </html>
+  `,
+
   // Event page
   '/admin/sites/testnation/pages/events/789': `
     <!DOCTYPE html>
@@ -153,7 +169,9 @@ const server = http.createServer((req, res) => {
       res.writeHead(204, {
         'Access-Control-Allow-Origin': '*',
         'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, X-Nat-User-Id, X-Nat-Nation-Slug',
+        // Identity now travels in the signed session token via Authorization;
+        // the old X-Nat-* identity headers are no longer accepted.
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
       });
       res.end();
       return;

--- a/extension/e2e/oauth-handoff.spec.ts
+++ b/extension/e2e/oauth-handoff.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * E2E tests for the session-token handoff (issue #10).
+ *
+ * After the NationBuilder OAuth flow, the backend redirects to the success page
+ * with the minted session token in the URL fragment. The oauth-callback content
+ * script reads it and stores it in chrome.storage via the background worker.
+ *
+ * These tests route the production success domain (natassistant.com) to the
+ * local mock server so the content script (which matches that host) injects.
+ */
+
+import { test, expect, getStorageValue } from './fixtures';
+
+const SESSION_TOKEN = 'header.payload.signature';
+const USER_ID = 'user-abc';
+const NATION_SLUG = 'examplenation';
+
+test.describe('Session token handoff', () => {
+  test('stores the session token from the success-page fragment', async ({
+    context,
+    extensionId,
+    nbPage,
+  }) => {
+    // Route the production success domain to the local mock server so the
+    // oauth-callback content script (matched on natassistant.com) injects.
+    await nbPage.route('**://natassistant.com/connected*', async (route) => {
+      const res = await route.fetch({ url: 'http://localhost:3456/connected' });
+      const body = await res.text();
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body,
+      });
+    });
+
+    // Navigate to the success URL exactly as the backend builds it:
+    //   ?user_id=...&nation=...#session_token=<jwt>
+    await nbPage.goto(
+      `https://natassistant.com/connected?user_id=${USER_ID}&nation=${NATION_SLUG}` +
+        `#session_token=${SESSION_TOKEN}`
+    );
+
+    // The content script should hand the token to the background worker, which
+    // stores it under `authToken` and marks the nation connected.
+    await expect
+      .poll(() => getStorageValue(context, extensionId, 'authToken'), {
+        timeout: 5000,
+      })
+      .toBe(SESSION_TOKEN);
+
+    expect(await getStorageValue(context, extensionId, 'userId')).toBe(USER_ID);
+    expect(await getStorageValue(context, extensionId, 'nationSlug')).toBe(
+      NATION_SLUG
+    );
+    expect(await getStorageValue(context, extensionId, 'nbConnected')).toBe(true);
+    expect(await getStorageValue(context, extensionId, 'nbNeedsReauth')).toBe(
+      false
+    );
+
+    // The token must be stripped from the URL fragment after handoff so it
+    // isn't left in the address bar / history.
+    expect(new URL(nbPage.url()).hash).toBe('');
+  });
+
+  test('ignores the success page when no token is present', async ({
+    context,
+    extensionId,
+    nbPage,
+  }) => {
+    await nbPage.route('**://natassistant.com/connected*', async (route) => {
+      const res = await route.fetch({ url: 'http://localhost:3456/connected' });
+      const body = await res.text();
+      await route.fulfill({ status: 200, contentType: 'text/html', body });
+    });
+
+    await nbPage.goto('https://natassistant.com/connected?error=missing_code');
+
+    // No token means nothing is written.
+    await nbPage.waitForTimeout(500);
+    expect(
+      await getStorageValue(context, extensionId, 'authToken')
+    ).toBeUndefined();
+  });
+});

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -9,19 +9,25 @@
     "alarms"
   ],
   "host_permissions": [
-    "*://*.nationbuilder.com/*"
+    "*://*.nationbuilder.com/*",
+    "https://natassistant.com/connected*"
   ],
-  "background": {
-    "service_worker": "background.js",
-    "type": "module"
-  },
   "content_scripts": [
     {
       "matches": ["*://*.nationbuilder.com/*"],
       "js": ["content.js"],
       "css": ["content.css"]
+    },
+    {
+      "matches": ["https://natassistant.com/connected*"],
+      "js": ["oauth-callback.js"],
+      "run_at": "document_start"
     }
   ],
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
   "action": {
     "default_title": "Nat - NationBuilder Assistant"
   }

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -66,6 +66,16 @@ interface UndoableAction {
 type MessageType =
   | { type: 'GET_AUTH_STATE' }
   | { type: 'SET_AUTH_STATE'; authToken: string; userId: string; tenantId: string }
+  | {
+      // Sent by the OAuth-success content script after the NationBuilder connect
+      // flow completes. Carries the minted session token (JWT) plus the identity
+      // the backend bound into it. Identity here is used only for UI display; the
+      // signed token is the source of truth on every backend request.
+      type: 'SET_SESSION';
+      sessionToken: string;
+      userId: string;
+      nationSlug: string;
+    }
   | { type: 'CLEAR_AUTH_STATE' }
   | { type: 'SET_NB_CONNECTION'; nbConnected: boolean; nbNeedsReauth?: boolean }
   | { type: 'SET_SUBSCRIPTION_STATUS'; status: AuthState['subscriptionStatus'] }
@@ -103,6 +113,15 @@ type BroadcastMessage =
 
 // Streaming endpoint - Lambda Function URL for SSE (configured at build time)
 const STREAMING_URL = 'https://streaming.nat.example.com'; // Lambda Function URL for SSE
+
+// Error codes the backend returns when session-token authentication fails.
+// On any of these the stored token is invalid/expired and the user must
+// re-run the NationBuilder connect flow to mint a fresh one.
+const AUTH_FAILURE_ERROR_CODES = new Set([
+  'MISSING_TOKEN',
+  'INVALID_TOKEN',
+  'TOKEN_EXPIRED',
+]);
 
 // ============================================================================
 // State Management
@@ -216,6 +235,51 @@ async function setNationSlug(nationSlug: string | null): Promise<void> {
     } else {
       chrome.storage.local.remove('nationSlug', () => resolve());
     }
+  });
+}
+
+/**
+ * Store a freshly minted session token after the NationBuilder OAuth flow.
+ *
+ * The signed token is the credential sent on every backend request. We also
+ * persist userId/nationSlug for UI display (the slug is still re-detected from
+ * the page URL by the content script per issue #7), and mark NB connected /
+ * reauth cleared so the chat UI unblocks.
+ */
+async function setSession(
+  sessionToken: string,
+  userId: string,
+  nationSlug: string
+): Promise<void> {
+  return new Promise((resolve) => {
+    chrome.storage.local.set(
+      {
+        authToken: sessionToken,
+        userId,
+        nationSlug,
+        nbConnected: true,
+        nbNeedsReauth: false,
+      },
+      () => resolve()
+    );
+  });
+}
+
+/**
+ * Handle a backend authentication failure (expired / missing / forged token).
+ *
+ * Clears the stored token so it is never reused, and routes the user to the
+ * existing "needs reauth" UI path (which prompts them to reconnect
+ * NationBuilder, minting a new token).
+ */
+async function handleAuthFailure(): Promise<void> {
+  return new Promise((resolve) => {
+    chrome.storage.local.set(
+      { nbNeedsReauth: true, nbConnected: false },
+      () => {
+        chrome.storage.local.remove('authToken', () => resolve());
+      }
+    );
   });
 }
 
@@ -387,10 +451,16 @@ async function handleSSEEvent(event: SSEEvent): Promise<void> {
     }
 
     case 'error': {
+      const errorCode = event.data.error_code as string;
+      // Auth failure (expired/invalid token) in the SSE stream: clear the
+      // token and surface reauth, same as a 401 on the initial response.
+      if (AUTH_FAILURE_ERROR_CODES.has(errorCode)) {
+        await handleAuthFailure();
+      }
       await broadcastToNbTabs({
         type: 'STREAMING_ERROR',
         error: event.data.error as string,
-        errorCode: event.data.error_code as string,
+        errorCode,
         retryAfter: event.data.retry_after as number | undefined,
       });
       break;
@@ -485,19 +555,20 @@ async function submitQuery(request: QueryRequest): Promise<{ success: boolean; e
       });
     });
 
-    // Make streaming request to Lambda Function URL
+    // Make streaming request to Lambda Function URL.
+    //
+    // Identity (user_id / nation_slug) is NOT sent in headers or the body: the
+    // backend derives it exclusively from the verified `Authorization: Bearer`
+    // session token, which closes the IDOR. The old forgeable X-Nat-* headers
+    // and body identity fields are intentionally removed.
     const response = await fetch(STREAMING_URL, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${authToken}`,
-        'X-Nat-User-Id': authState.userId || '',
-        'X-Nat-Nation-Slug': authState.nationSlug || '',
       },
       body: JSON.stringify({
         query: request.query,
-        user_id: authState.userId,
-        nation_slug: authState.nationSlug,
         context: request.context || {},
         confirmed_tools: streamingState.confirmedTools,
         undo_stack: request.undoStack || [],
@@ -510,12 +581,23 @@ async function submitQuery(request: QueryRequest): Promise<{ success: boolean; e
       streamingState.isStreaming = false;
       streamingState.abortController = null;
 
-      // Map HTTP status to error codes
-      let errorCode = 'API_ERROR';
-      if (response.status === 402) errorCode = 'PAYMENT_REQUIRED';
-      else if (response.status === 403) errorCode = 'FORBIDDEN';
-      else if (response.status === 404) errorCode = 'NATION_NOT_FOUND';
-      else if (response.status === 429) errorCode = 'RATE_LIMIT_EXCEEDED';
+      // Prefer the backend's structured error_code (e.g. auth failures), then
+      // fall back to mapping the HTTP status to a code.
+      const backendCode = (errorData as { error_code?: string }).error_code;
+      let errorCode = backendCode || 'API_ERROR';
+      if (!backendCode) {
+        if (response.status === 401) errorCode = 'INVALID_TOKEN';
+        else if (response.status === 402) errorCode = 'PAYMENT_REQUIRED';
+        else if (response.status === 403) errorCode = 'FORBIDDEN';
+        else if (response.status === 404) errorCode = 'NATION_NOT_FOUND';
+        else if (response.status === 429) errorCode = 'RATE_LIMIT_EXCEEDED';
+      }
+
+      // On auth failure, clear the stored token and surface reauth so the user
+      // reconnects NationBuilder (minting a fresh token).
+      if (response.status === 401 || AUTH_FAILURE_ERROR_CODES.has(errorCode)) {
+        await handleAuthFailure();
+      }
 
       await broadcastToNbTabs({
         type: 'STREAMING_ERROR',
@@ -645,6 +727,13 @@ chrome.runtime.onMessage.addListener((
 
     case 'SET_AUTH_STATE': {
       setAuthState(message.authToken, message.userId, message.tenantId)
+        .then(() => notifyAuthStateChanged())
+        .then(() => sendResponse({ success: true }));
+      return true;
+    }
+
+    case 'SET_SESSION': {
+      setSession(message.sessionToken, message.userId, message.nationSlug)
         .then(() => notifyAuthStateChanged())
         .then(() => sendResponse({ success: true }));
       return true;

--- a/extension/src/content/oauth-callback.ts
+++ b/extension/src/content/oauth-callback.ts
@@ -1,0 +1,81 @@
+/**
+ * OAuth-success content script.
+ *
+ * Runs on the Nat OAuth success page (configured via SUCCESS_REDIRECT_URL on the
+ * backend, e.g. https://natassistant.com/connected). After the NationBuilder
+ * connect flow completes, the backend's `nb_oauth_callback` Lambda redirects
+ * here with:
+ *
+ *   ?user_id=<id>&nation=<slug>#session_token=<jwt>
+ *
+ * The minted session token is delivered in the URL *fragment* so it never
+ * reaches the success page's server or its access logs. This script reads it,
+ * hands it to the background service worker (which stores it in chrome.storage
+ * for use as `Authorization: Bearer`), then strips the fragment from the URL so
+ * the token isn't left lingering in the address bar / history.
+ */
+
+function readToken(): {
+  sessionToken: string;
+  userId: string;
+  nationSlug: string;
+} | null {
+  // Token lives in the fragment (after '#').
+  const hash = window.location.hash.startsWith('#')
+    ? window.location.hash.slice(1)
+    : window.location.hash;
+  const fragment = new URLSearchParams(hash);
+  const sessionToken = fragment.get('session_token');
+  if (!sessionToken) {
+    return null;
+  }
+
+  // Identity is for UI display only; the signed token is the source of truth.
+  const query = new URLSearchParams(window.location.search);
+  const userId = query.get('user_id') || '';
+  const nationSlug = query.get('nation') || '';
+
+  return { sessionToken, userId, nationSlug };
+}
+
+function clearFragment(): void {
+  try {
+    // Remove the fragment so the token isn't left in the address bar/history.
+    history.replaceState(
+      null,
+      '',
+      window.location.pathname + window.location.search
+    );
+  } catch {
+    // history may be unavailable in some contexts; non-fatal.
+  }
+}
+
+function handoffToken(): void {
+  const session = readToken();
+  if (!session) {
+    return;
+  }
+
+  try {
+    const sending = chrome.runtime.sendMessage({
+      type: 'SET_SESSION',
+      sessionToken: session.sessionToken,
+      userId: session.userId,
+      nationSlug: session.nationSlug,
+    });
+    if (sending && typeof sending.catch === 'function') {
+      sending.catch(() => {});
+    }
+  } catch {
+    // chrome.runtime may be unavailable if the extension context was invalidated.
+  }
+
+  clearFragment();
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', handoffToken);
+} else {
+  handoffToken();
+}

--- a/extension/vite.config.ts
+++ b/extension/vite.config.ts
@@ -50,6 +50,7 @@ export default defineConfig({
     rollupOptions: {
       input: {
         content: resolve(__dirname, 'src/content/index.tsx'),
+        'oauth-callback': resolve(__dirname, 'src/content/oauth-callback.ts'),
         background: resolve(__dirname, 'src/background/index.ts'),
       },
       output: {

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -357,6 +357,7 @@ Resources:
           USERS_TABLE: !Ref UsersTable
           NB_CLIENT_ID_SECRET: !Sub 'nat/nb-client-id-${Environment}'
           NB_CLIENT_SECRET_SECRET: !Sub 'nat/nb-client-secret-${Environment}'
+          SESSION_JWT_SECRET_NAME: !Sub 'nat/session-jwt-secret-${Environment}'
           SUCCESS_REDIRECT_URL: !Sub 'https://natassistant.com/connected?env=${Environment}'
           ERROR_REDIRECT_URL: !Sub 'https://natassistant.com/connection-error?env=${Environment}'
       Tags:
@@ -656,6 +657,7 @@ Resources:
           USERS_TABLE: !Ref UsersTable
           TENANTS_TABLE: !Ref TenantsTable
           ANTHROPIC_API_KEY_SECRET: !Sub 'nat/anthropic-api-key-${Environment}'
+          SESSION_JWT_SECRET_NAME: !Sub 'nat/session-jwt-secret-${Environment}'
           CLAUDE_MODEL: 'claude-haiku-4-5-20251001'
       Tags:
         - Key: Environment
@@ -760,6 +762,7 @@ Resources:
           USERS_TABLE: !Ref UsersTable
           TENANTS_TABLE: !Ref TenantsTable
           ANTHROPIC_API_KEY_SECRET: !Sub 'nat/anthropic-api-key-${Environment}'
+          SESSION_JWT_SECRET_NAME: !Sub 'nat/session-jwt-secret-${Environment}'
           CLAUDE_MODEL: 'claude-haiku-4-5-20251001'
       Tags:
         - Key: Environment

--- a/src/lambdas/nat_agent/handler.py
+++ b/src/lambdas/nat_agent/handler.py
@@ -27,6 +27,17 @@ from src.lambdas.shared.subscription_middleware import (
     verify_nation_subscription,
 )
 
+try:  # Resolve in both pytest (repo root) and flattened Lambda packages.
+    from src.lambdas.shared.session_token import (
+        SessionTokenError,
+        authenticate_request,
+    )
+except ModuleNotFoundError:  # pragma: no cover - exercised only in Lambda
+    from shared.session_token import (  # type: ignore[no-redef]
+        SessionTokenError,
+        authenticate_request,
+    )
+
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
@@ -320,7 +331,7 @@ def handler(event: dict[str, Any], context: Any) -> LambdaResponse:
     headers = {
         "Content-Type": "application/json",
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Headers": "Content-Type,X-Nat-User-Id,X-Nat-Nation-Slug",
+        "Access-Control-Allow-Headers": "Content-Type,Authorization",
     }
 
     try:
@@ -342,43 +353,34 @@ def handler(event: dict[str, Any], context: Any) -> LambdaResponse:
                 "headers": headers,
             }
 
-        # Extract required fields
-        query = body.get("query")
-        user_id = body.get("user_id")
-        nation_slug = body.get("nation_slug")
-        page_context = body.get("context", {})
+        # Authenticate the caller. user_id and nation_slug are derived from the
+        # signed session-token claims, NOT from client-supplied body/header
+        # values (which are forgeable). This closes the IDOR: a token minted for
+        # nation A cannot act on nation B.
+        try:
+            session = authenticate_request(event)
+        except SessionTokenError as e:
+            logger.warning(f"Authentication failed: {e.code} - {e.message}")
+            return {
+                "statusCode": e.http_status,
+                "body": json.dumps({
+                    "error": e.message,
+                    "error_code": e.code,
+                }),
+                "headers": headers,
+            }
 
-        # Also check headers for user_id / nation_slug (middleware may have set them)
-        request_headers = event.get("headers", {}) or {}
-        if not user_id:
-            user_id = (
-                request_headers.get("X-Nat-User-Id")
-                or request_headers.get("x-nat-user-id")
-            )
-        if not nation_slug:
-            nation_slug = (
-                request_headers.get("X-Nat-Nation-Slug")
-                or request_headers.get("x-nat-nation-slug")
-            )
+        user_id = session.user_id
+        nation_slug = session.nation_slug
+
+        # Extract request payload (identity fields are ignored if present).
+        query = body.get("query")
+        page_context = body.get("context", {})
 
         if not query:
             return {
                 "statusCode": 400,
                 "body": json.dumps({"error": "Missing required field: query"}),
-                "headers": headers,
-            }
-
-        if not user_id:
-            return {
-                "statusCode": 400,
-                "body": json.dumps({"error": "Missing required field: user_id"}),
-                "headers": headers,
-            }
-
-        if not nation_slug:
-            return {
-                "statusCode": 400,
-                "body": json.dumps({"error": "Missing required field: nation_slug"}),
                 "headers": headers,
             }
 

--- a/src/lambdas/nat_agent_streaming/handler.py
+++ b/src/lambdas/nat_agent_streaming/handler.py
@@ -27,6 +27,19 @@ from src.lambdas.shared.subscription_middleware import (
     verify_nation_subscription,
 )
 
+try:  # Resolve in both pytest (repo root) and flattened Lambda packages.
+    from src.lambdas.shared.session_token import (
+        SessionContext,
+        SessionTokenError,
+        authenticate_request,
+    )
+except ModuleNotFoundError:  # pragma: no cover - exercised only in Lambda
+    from shared.session_token import (  # type: ignore[no-redef]
+        SessionContext,
+        SessionTokenError,
+        authenticate_request,
+    )
+
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
@@ -445,6 +458,25 @@ async def stream_agent_response(
         })
 
 
+def authenticated_body(event: dict[str, Any], body: dict[str, Any]) -> dict[str, Any]:
+    """
+    Authenticate a request and return a copy of the body with trusted identity.
+
+    ``user_id`` and ``nation_slug`` are taken from the verified session-token
+    claims, overwriting any client-supplied values (which are forgeable). This
+    closes the IDOR for the streaming path.
+
+    Raises:
+        SessionTokenError: If authentication fails (caller returns 401 / emits
+            an auth error event).
+    """
+    session: SessionContext = authenticate_request(event)
+    authenticated = dict(body)
+    authenticated["user_id"] = session.user_id
+    authenticated["nation_slug"] = session.nation_slug
+    return authenticated
+
+
 async def process_streaming_request(body: dict[str, Any]) -> AsyncGenerator[str, None]:
     """
     Process a streaming request and yield SSE events.
@@ -613,6 +645,20 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             "body": json.dumps({"error": "Invalid JSON in request body"}),
         }
 
+    # Authenticate before any work; derive identity from the signed token.
+    try:
+        body = authenticated_body(event, body)
+    except SessionTokenError as e:
+        logger.warning(f"Authentication failed: {e.code} - {e.message}")
+        return {
+            "statusCode": e.http_status,
+            "headers": {
+                "Content-Type": "application/json",
+                "Access-Control-Allow-Origin": "*",
+            },
+            "body": json.dumps({"error": e.message, "error_code": e.code}),
+        }
+
     # For non-streaming invocation (testing), return accumulated response
     # The actual streaming is handled by the streaming handler wrapper
     async def collect_response() -> str:
@@ -630,7 +676,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             "Cache-Control": "no-cache",
             "Connection": "keep-alive",
             "Access-Control-Allow-Origin": "*",
-            "Access-Control-Allow-Headers": "Content-Type,X-Nat-User-Id,X-Nat-Nation-Slug",
+            "Access-Control-Allow-Headers": "Content-Type,Authorization",
         },
         "body": sse_response,
     }
@@ -673,6 +719,18 @@ async def streaming_handler(event: dict[str, Any], response_stream: Any) -> None
         error_event = format_sse_event(SSE_EVENT_ERROR, {
             "error": "Invalid JSON in request body",
             "error_code": "BAD_REQUEST",
+        })
+        await response_stream.write(error_event.encode("utf-8"))
+        return
+
+    # Authenticate before any work; derive identity from the signed token.
+    try:
+        body = authenticated_body(event, body)
+    except SessionTokenError as e:
+        logger.warning(f"Authentication failed: {e.code} - {e.message}")
+        error_event = format_sse_event(SSE_EVENT_ERROR, {
+            "error": e.message,
+            "error_code": e.code,
         })
         await response_stream.write(error_event.encode("utf-8"))
         return

--- a/src/lambdas/nb_oauth_callback/handler.py
+++ b/src/lambdas/nb_oauth_callback/handler.py
@@ -21,6 +21,17 @@ import boto3
 import urllib3
 from botocore.exceptions import ClientError
 
+try:  # Resolve in both pytest (repo root) and flattened Lambda packages.
+    from src.lambdas.shared.session_token import (
+        get_session_secret,
+        mint_session_token,
+    )
+except ModuleNotFoundError:  # pragma: no cover - exercised only in Lambda
+    from shared.session_token import (  # type: ignore[no-redef]
+        get_session_secret,
+        mint_session_token,
+    )
+
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
@@ -479,8 +490,24 @@ def handler(event: dict[str, Any], context: Any) -> LambdaResponse:
 
         logger.info(f"Successfully connected NB for nation {nb_slug} (user {user_id})")
 
-        # Redirect to success page with nation info
-        success_url = f"{SUCCESS_REDIRECT_URL}?user_id={user_id}&nation={nb_slug}"
+        # Mint a short-lived signed session token. The extension stores this and
+        # sends it as `Authorization: Bearer` on every backend request; the
+        # backend derives user_id / nation_slug from its signed claims instead
+        # of trusting forgeable client headers.
+        session_token = mint_session_token(
+            user_id=user_id,
+            nation_slug=nb_slug,
+            secret=get_session_secret(),
+        )
+
+        # Redirect to success page with nation info and the session token. The
+        # token is delivered in the URL fragment so it is not sent to the
+        # success page's server or written to its access logs.
+        success_query = urlencode({"user_id": user_id, "nation": nb_slug})
+        success_url = (
+            f"{SUCCESS_REDIRECT_URL}?{success_query}"
+            f"#session_token={session_token}"
+        )
         return create_redirect_response(success_url)
 
     except ClientError as e:

--- a/src/lambdas/nb_oauth_callback/handler.py
+++ b/src/lambdas/nb_oauth_callback/handler.py
@@ -504,8 +504,11 @@ def handler(event: dict[str, Any], context: Any) -> LambdaResponse:
         # token is delivered in the URL fragment so it is not sent to the
         # success page's server or written to its access logs.
         success_query = urlencode({"user_id": user_id, "nation": nb_slug})
+        # SUCCESS_REDIRECT_URL may already carry a query string (e.g. ?env=prod),
+        # so pick the correct separator to avoid a malformed double "?".
+        separator = "&" if "?" in SUCCESS_REDIRECT_URL else "?"
         success_url = (
-            f"{SUCCESS_REDIRECT_URL}?{success_query}"
+            f"{SUCCESS_REDIRECT_URL}{separator}{success_query}"
             f"#session_token={session_token}"
         )
         return create_redirect_response(success_url)

--- a/src/lambdas/shared/session_token.py
+++ b/src/lambdas/shared/session_token.py
@@ -1,0 +1,279 @@
+"""
+Session Token (JWT) helper.
+
+Mints and verifies short-lived HS256 JSON Web Tokens that authenticate Nat API
+callers and bind each request to a specific ``(user_id, nation_slug)`` pair.
+
+The token is implemented with only the Python standard library so it can be
+bundled into a Lambda deployment package without adding a third-party
+dependency (this mirrors the codebase convention of using ``urllib3`` / stdlib
+instead of extra packages).
+
+Security model
+--------------
+The signed claims are the source of truth for caller identity. Handlers MUST
+derive ``user_id`` and ``nation_slug`` from a verified token rather than from
+client-supplied headers or body fields, which are forgeable. This is what
+closes the IDOR where any caller could read another nation's data by naming its
+slug.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger()
+
+# Secrets Manager path for the signing secret (per environment in production).
+SESSION_JWT_SECRET_NAME = os.environ.get(
+    "SESSION_JWT_SECRET_NAME", "nat/session-jwt-secret"
+)
+
+# Default token lifetime. Short-lived: on expiry the extension re-authenticates
+# (re-runs the NationBuilder OAuth connect flow) to mint a fresh token.
+DEFAULT_TTL_SECONDS = int(os.environ.get("SESSION_TOKEN_TTL_SECONDS", "86400"))
+
+_JWT_HEADER = {"alg": "HS256", "typ": "JWT"}
+
+# Cache the signing secret across warm Lambda invocations.
+_cached_secret: str | None = None
+
+
+class SessionTokenError(Exception):
+    """Raised when a session token is missing, malformed, expired, or forged."""
+
+    def __init__(
+        self,
+        message: str,
+        code: str = "INVALID_TOKEN",
+        http_status: int = 401,
+    ) -> None:
+        self.message = message
+        self.code = code
+        self.http_status = http_status
+        super().__init__(message)
+
+
+@dataclass
+class SessionContext:
+    """Authenticated caller identity derived from a verified session token."""
+
+    user_id: str
+    nation_slug: str
+
+
+def _b64url_encode(data: bytes) -> str:
+    """Base64url-encode without padding (JWT segment encoding)."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(segment: str) -> bytes:
+    """Base64url-decode a JWT segment, restoring stripped padding."""
+    padding = "=" * (-len(segment) % 4)
+    return base64.urlsafe_b64decode(segment + padding)
+
+
+def _sign(signing_input: bytes, secret: str) -> str:
+    """Compute the base64url HMAC-SHA256 signature for a signing input."""
+    digest = hmac.new(secret.encode("utf-8"), signing_input, hashlib.sha256).digest()
+    return _b64url_encode(digest)
+
+
+def get_secrets_manager_client() -> Any:
+    """Get Secrets Manager client (allows mocking in tests)."""
+    return boto3.client("secretsmanager")
+
+
+def get_session_secret() -> str:
+    """
+    Retrieve the JWT signing secret from Secrets Manager.
+
+    The secret may be stored as a plain string or as JSON containing a
+    ``secret`` / ``value`` / ``key`` field. Cached for warm invocations.
+    """
+    global _cached_secret
+    if _cached_secret is not None:
+        return _cached_secret
+
+    client = get_secrets_manager_client()
+    try:
+        response = client.get_secret_value(SecretId=SESSION_JWT_SECRET_NAME)
+    except ClientError as e:
+        logger.error(f"Failed to retrieve session JWT secret: {e}")
+        raise
+
+    secret_str: str = response.get("SecretString", "")
+    try:
+        data = json.loads(secret_str)
+    except json.JSONDecodeError:
+        _cached_secret = secret_str
+        return secret_str
+
+    if isinstance(data, dict):
+        for key in ("secret", "value", "key", "jwt_secret"):
+            if key in data:
+                _cached_secret = str(data[key])
+                return _cached_secret
+        if data:
+            _cached_secret = str(next(iter(data.values())))
+            return _cached_secret
+
+    _cached_secret = secret_str
+    return secret_str
+
+
+def reset_secret_cache() -> None:
+    """Clear the cached signing secret (used in tests)."""
+    global _cached_secret
+    _cached_secret = None
+
+
+def mint_session_token(
+    user_id: str,
+    nation_slug: str,
+    secret: str,
+    ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    now: float | None = None,
+) -> str:
+    """
+    Mint a signed HS256 session token binding a user to a nation.
+
+    Args:
+        user_id: Authenticated user identifier.
+        nation_slug: Nation the user is authorized for.
+        secret: HMAC signing secret.
+        ttl_seconds: Lifetime of the token in seconds.
+        now: Override for the current time (testing). Defaults to ``time.time()``.
+
+    Returns:
+        Encoded JWT string (``header.payload.signature``).
+    """
+    if not user_id or not nation_slug:
+        raise ValueError("user_id and nation_slug are required to mint a session token")
+
+    issued_at = int(now if now is not None else time.time())
+    claims: dict[str, Any] = {
+        "user_id": user_id,
+        "nation_slug": nation_slug,
+        "iat": issued_at,
+        "exp": issued_at + int(ttl_seconds),
+    }
+
+    header_segment = _b64url_encode(
+        json.dumps(_JWT_HEADER, separators=(",", ":")).encode("utf-8")
+    )
+    payload_segment = _b64url_encode(
+        json.dumps(claims, separators=(",", ":")).encode("utf-8")
+    )
+    signing_input = f"{header_segment}.{payload_segment}".encode("ascii")
+    signature = _sign(signing_input, secret)
+    return f"{header_segment}.{payload_segment}.{signature}"
+
+
+def verify_session_token(
+    token: str,
+    secret: str,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """
+    Verify a session token's signature and expiry and return its claims.
+
+    Raises:
+        SessionTokenError: If the token is missing, malformed, signed with the
+            wrong secret/algorithm, tampered with, or expired.
+    """
+    if not token:
+        raise SessionTokenError("Missing session token", code="MISSING_TOKEN")
+
+    parts = token.split(".")
+    if len(parts) != 3:
+        raise SessionTokenError("Malformed session token")
+
+    header_segment, payload_segment, signature = parts
+    signing_input = f"{header_segment}.{payload_segment}".encode("ascii")
+    expected_sig = _sign(signing_input, secret)
+
+    # Constant-time comparison; rejects tampered payloads and "alg: none".
+    if not hmac.compare_digest(expected_sig, signature):
+        raise SessionTokenError("Invalid token signature")
+
+    try:
+        header = json.loads(_b64url_decode(header_segment))
+        claims = json.loads(_b64url_decode(payload_segment))
+    except (ValueError, json.JSONDecodeError):
+        raise SessionTokenError("Malformed session token payload")
+
+    if not isinstance(header, dict) or header.get("alg") != "HS256":
+        raise SessionTokenError("Unsupported token algorithm")
+
+    if not isinstance(claims, dict):
+        raise SessionTokenError("Malformed session token claims")
+
+    exp = claims.get("exp")
+    current = int(now if now is not None else time.time())
+    if not isinstance(exp, (int, float)) or current >= int(exp):
+        raise SessionTokenError("Session token expired", code="TOKEN_EXPIRED")
+
+    user_id = claims.get("user_id")
+    nation_slug = claims.get("nation_slug")
+    if not user_id or not nation_slug:
+        raise SessionTokenError("Session token missing identity claims")
+
+    return claims
+
+
+def extract_bearer_token(headers: dict[str, str]) -> str:
+    """
+    Extract the bearer token from a case-insensitive ``Authorization`` header.
+
+    Raises:
+        SessionTokenError: If the header is missing or not a bearer token.
+    """
+    normalized = {k.lower(): v for k, v in (headers or {}).items()}
+    auth = normalized.get("authorization", "")
+    if not auth:
+        raise SessionTokenError(
+            "Missing Authorization header", code="MISSING_TOKEN"
+        )
+
+    pieces = auth.split(" ", 1)
+    if len(pieces) != 2 or pieces[0].lower() != "bearer" or not pieces[1].strip():
+        raise SessionTokenError(
+            "Malformed Authorization header", code="MISSING_TOKEN"
+        )
+    return pieces[1].strip()
+
+
+def authenticate_request(
+    event: dict[str, Any],
+    secret: str | None = None,
+) -> SessionContext:
+    """
+    Authenticate a Lambda request from its ``Authorization: Bearer`` token.
+
+    Returns the verified caller identity. ``user_id`` and ``nation_slug`` come
+    exclusively from the signed claims — any client-supplied header or body
+    values are ignored, closing the IDOR.
+
+    Raises:
+        SessionTokenError: If authentication fails (caller should return 401).
+    """
+    headers = event.get("headers", {}) or {}
+    token = extract_bearer_token(headers)
+    signing_secret = secret if secret is not None else get_session_secret()
+    claims = verify_session_token(token, signing_secret)
+    return SessionContext(
+        user_id=str(claims["user_id"]),
+        nation_slug=str(claims["nation_slug"]),
+    )

--- a/src/lambdas/shared/subscription_middleware.py
+++ b/src/lambdas/shared/subscription_middleware.py
@@ -19,6 +19,11 @@ from typing import Any, TypedDict
 import boto3
 from botocore.exceptions import ClientError
 
+from .session_token import (
+    SessionTokenError,
+    authenticate_request,
+)
+
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
@@ -106,7 +111,11 @@ def get_dynamodb_resource() -> Any:
 
 def extract_nation_from_headers(headers: dict[str, str]) -> NationContext:
     """
-    Extract user and nation identity from request headers.
+    DEPRECATED: Extract user and nation identity from request headers.
+
+    These ``X-Nat-*`` headers are client-supplied and forgeable. New code must
+    use :func:`extract_nation_from_session`, which derives identity from a
+    signed session token. Retained only for backwards compatibility.
 
     Headers:
     - X-Nat-User-Id: Required user identifier (for rate limiting)
@@ -133,6 +142,28 @@ def extract_nation_from_headers(headers: dict[str, str]) -> NationContext:
         )
 
     return NationContext(user_id=user_id, nation_slug=nation_slug)
+
+
+def extract_nation_from_session(event: dict[str, Any]) -> NationContext:
+    """
+    Extract user and nation identity from the verified session token.
+
+    Unlike :func:`extract_nation_from_headers`, identity here comes from the
+    signed token claims (``Authorization: Bearer``), so a caller cannot forge a
+    ``nation_slug`` to access another nation's data (closes IDOR).
+
+    Raises:
+        SubscriptionError: With http_status 401 if authentication fails.
+    """
+    try:
+        session = authenticate_request(event)
+    except SessionTokenError as e:
+        raise SubscriptionError(
+            code=SubscriptionErrorCode.MISSING_USER_ID,
+            message=e.message,
+            http_status=e.http_status,
+        )
+    return NationContext(user_id=session.user_id, nation_slug=session.nation_slug)
 
 
 def get_nation_subscription(nation_slug: str) -> dict[str, Any]:
@@ -518,8 +549,9 @@ class NationSubscriptionMiddleware:
         Raises:
             SubscriptionError: If verification fails
         """
-        headers = event.get("headers", {}) or {}
-        nation_context = extract_nation_from_headers(headers)
+        # Identity is derived from the verified session token, not from
+        # client-supplied X-Nat-* headers (which are forgeable).
+        nation_context = extract_nation_from_session(event)
 
         return verify_nation_subscription(
             user_id=nation_context.user_id,

--- a/tests/integration/test_nb_oauth_integration.py
+++ b/tests/integration/test_nb_oauth_integration.py
@@ -222,6 +222,10 @@ class TestOAuthCallbackIntegration:
                 "src.lambdas.nb_oauth_callback.handler.get_secret",
                 side_effect=[TEST_CLIENT_ID, TEST_CLIENT_SECRET],
             ),
+            patch(
+                "src.lambdas.nb_oauth_callback.handler.get_session_secret",
+                return_value="test-session-secret",
+            ),
             patch("urllib3.PoolManager", return_value=mock_http),
         ):
             response = handler(event, None)
@@ -322,6 +326,10 @@ class TestOAuthCallbackIntegration:
                 "src.lambdas.nb_oauth_callback.handler.get_secret",
                 side_effect=[TEST_CLIENT_ID, TEST_CLIENT_SECRET],
             ),
+            patch(
+                "src.lambdas.nb_oauth_callback.handler.get_session_secret",
+                return_value="test-session-secret",
+            ),
             patch("urllib3.PoolManager", return_value=mock_http),
         ):
             response = handler(event, None)
@@ -367,6 +375,10 @@ class TestOAuthCallbackIntegration:
                 "src.lambdas.nb_oauth_callback.handler.get_secret",
                 side_effect=[TEST_CLIENT_ID, TEST_CLIENT_SECRET],
             ),
+            patch(
+                "src.lambdas.nb_oauth_callback.handler.get_session_secret",
+                return_value="test-session-secret",
+            ),
             patch("urllib3.PoolManager", return_value=mock_http),
         ):
             response = handler(event, None)
@@ -400,6 +412,10 @@ class TestOAuthCallbackIntegration:
             patch(
                 "src.lambdas.nb_oauth_callback.handler.get_secret",
                 side_effect=[TEST_CLIENT_ID, TEST_CLIENT_SECRET],
+            ),
+            patch(
+                "src.lambdas.nb_oauth_callback.handler.get_session_secret",
+                return_value="test-session-secret",
             ),
             patch("urllib3.PoolManager", return_value=mock_http),
         ):
@@ -509,6 +525,10 @@ class TestOAuthCallbackIntegration:
                 "src.lambdas.nb_oauth_callback.handler.get_secret",
                 side_effect=[TEST_CLIENT_ID, TEST_CLIENT_SECRET],
             ),
+            patch(
+                "src.lambdas.nb_oauth_callback.handler.get_session_secret",
+                return_value="test-session-secret",
+            ),
             patch("urllib3.PoolManager", return_value=mock_http),
         ):
             response = handler(event, None)
@@ -578,6 +598,10 @@ class TestOAuthCallbackIntegration:
             patch(
                 "src.lambdas.nb_oauth_callback.handler.get_secret",
                 side_effect=[TEST_CLIENT_ID, TEST_CLIENT_SECRET],
+            ),
+            patch(
+                "src.lambdas.nb_oauth_callback.handler.get_session_secret",
+                return_value="test-session-secret",
             ),
             patch("urllib3.PoolManager", return_value=mock_http),
         ):

--- a/tests/test_nat_agent.py
+++ b/tests/test_nat_agent.py
@@ -17,6 +17,7 @@ from src.lambdas.nat_agent.handler import (
     get_user_info,
     handler,
 )
+from src.lambdas.shared.session_token import mint_session_token
 
 
 # Test data
@@ -26,16 +27,34 @@ TEST_NATION_SLUG = "testnation"
 TEST_NB_SLUG = "testnation"
 TEST_NB_TOKEN = "nb_test_token_abc123"
 TEST_API_KEY = "sk-ant-test-key"
+TEST_JWT_SECRET = "test-session-secret"
+
+
+def bearer(
+    user_id: str = TEST_USER_ID,
+    nation_slug: str = TEST_NATION_SLUG,
+    secret: str = TEST_JWT_SECRET,
+) -> str:
+    """Build an `Authorization: Bearer <jwt>` header value for tests."""
+    return f"Bearer {mint_session_token(user_id, nation_slug, secret)}"
 
 
 def create_api_event(
     body: dict[str, Any] | None = None,
     headers: dict[str, str] | None = None,
 ) -> dict[str, Any]:
-    """Create a mock API Gateway event."""
+    """
+    Create a mock API Gateway event.
+
+    When ``headers`` is not provided, a valid session-token Authorization header
+    for the default test user/nation is injected so most handler tests exercise
+    the post-authentication path. Pass ``headers={}`` to omit it.
+    """
+    if headers is None:
+        headers = {"Authorization": bearer()}
     return {
         "body": json.dumps(body) if body else "",
-        "headers": headers or {},
+        "headers": headers,
         "httpMethod": "POST",
         "path": "/agent/query",
     }
@@ -255,6 +274,15 @@ class TestGetUserInfo:
 class TestHandler:
     """Tests for the main Lambda handler (per-nation architecture)."""
 
+    @pytest.fixture(autouse=True)
+    def _patch_session_secret(self) -> Any:
+        """Use a deterministic signing secret for session-token verification."""
+        with patch(
+            "src.lambdas.shared.session_token.get_session_secret",
+            return_value=TEST_JWT_SECRET,
+        ):
+            yield
+
     def _valid_body(self, **overrides: Any) -> dict[str, Any]:
         """Build a request body with all required per-nation fields."""
         body: dict[str, Any] = {
@@ -298,29 +326,55 @@ class TestHandler:
         body = json.loads(response["body"])
         assert "query" in body["error"]
 
-    def test_missing_user_id(self) -> None:
-        """Test that missing user_id returns 400."""
-        event = create_api_event(body={
-            "query": "test query",
-            "nation_slug": TEST_NATION_SLUG,
-        })
+    def test_missing_token_returns_401(self) -> None:
+        """A request with no Authorization header is rejected with 401."""
+        event = create_api_event(body=self._valid_body(), headers={})
         response = handler(event, None)
 
-        assert response["statusCode"] == 400
+        assert response["statusCode"] == 401
         body = json.loads(response["body"])
-        assert "user_id" in body["error"]
+        assert body["error_code"] == "MISSING_TOKEN"
 
-    def test_missing_nation_slug(self) -> None:
-        """Test that missing nation_slug returns 400."""
-        event = create_api_event(body={
-            "query": "test query",
-            "user_id": TEST_USER_ID,
-        })
+    def test_forged_token_returns_401(self) -> None:
+        """A token signed with the wrong secret is rejected with 401."""
+        event = create_api_event(
+            body=self._valid_body(),
+            headers={"Authorization": bearer(secret="attacker-secret")},
+        )
         response = handler(event, None)
 
-        assert response["statusCode"] == 400
+        assert response["statusCode"] == 401
         body = json.loads(response["body"])
-        assert "nation_slug" in body["error"]
+        assert body["error_code"] == "INVALID_TOKEN"
+
+    def test_tampered_token_returns_401(self) -> None:
+        """Flipping a character in a valid token invalidates the signature."""
+        token = mint_session_token(TEST_USER_ID, TEST_NATION_SLUG, TEST_JWT_SECRET)
+        # Corrupt the payload segment.
+        header_seg, payload_seg, sig = token.split(".")
+        tampered = f"{header_seg}.{payload_seg[:-1]}{'A' if payload_seg[-1] != 'A' else 'B'}.{sig}"
+        event = create_api_event(
+            body=self._valid_body(),
+            headers={"Authorization": f"Bearer {tampered}"},
+        )
+        response = handler(event, None)
+
+        assert response["statusCode"] == 401
+
+    def test_expired_token_returns_401(self) -> None:
+        """An expired token is rejected with 401."""
+        expired = mint_session_token(
+            TEST_USER_ID, TEST_NATION_SLUG, TEST_JWT_SECRET, ttl_seconds=-10
+        )
+        event = create_api_event(
+            body=self._valid_body(),
+            headers={"Authorization": f"Bearer {expired}"},
+        )
+        response = handler(event, None)
+
+        assert response["statusCode"] == 401
+        body = json.loads(response["body"])
+        assert body["error_code"] == "TOKEN_EXPIRED"
 
     @patch("src.lambdas.nat_agent.handler.verify_nation_subscription")
     @patch("src.lambdas.nat_agent.handler.check_rate_limit")
@@ -492,52 +546,56 @@ class TestHandler:
     @patch("src.lambdas.nat_agent.handler.check_rate_limit")
     @patch("src.lambdas.nat_agent.handler.check_and_reset_billing_cycle_nation")
     @patch("src.lambdas.nat_agent.handler.get_nb_tokens_by_nation")
-    def test_ids_from_headers(
+    def test_forged_headers_are_ignored_idor_closed(
         self,
         mock_get_tokens: MagicMock,
         mock_billing: MagicMock,
         mock_rate: MagicMock,
         mock_verify: MagicMock,
     ) -> None:
-        """Test that user_id and nation_slug can be supplied via headers."""
+        """
+        IDOR closure: a valid token for nation A cannot be used to act on
+        nation B by supplying forged X-Nat-* headers. Identity comes from the
+        token claims only.
+        """
         mock_get_tokens.return_value = None  # Stop after token lookup
 
         event = create_api_event(
-            body={"query": "test query"},
+            body={"query": "test query", "nation_slug": "victim-nation"},
             headers={
-                "X-Nat-User-Id": TEST_USER_ID,
-                "X-Nat-Nation-Slug": TEST_NATION_SLUG,
+                "Authorization": bearer(TEST_USER_ID, TEST_NATION_SLUG),
+                # Attacker tries to target another nation via legacy headers.
+                "X-Nat-User-Id": "attacker",
+                "X-Nat-Nation-Slug": "victim-nation",
             },
         )
         response = handler(event, None)
 
-        # Reaches per-nation token lookup, then returns NB_NOT_CONNECTED
         assert response["statusCode"] == 403
         body = json.loads(response["body"])
         assert body["error_code"] == "NB_NOT_CONNECTED"
+        # The token's nation is used, NOT the forged header/body nation.
         mock_get_tokens.assert_called_once_with(TEST_NATION_SLUG)
         mock_billing.assert_called_once_with(TEST_NATION_SLUG)
+        mock_verify.assert_called_once_with(TEST_USER_ID, TEST_NATION_SLUG)
 
     @patch("src.lambdas.nat_agent.handler.verify_nation_subscription")
     @patch("src.lambdas.nat_agent.handler.check_rate_limit")
     @patch("src.lambdas.nat_agent.handler.check_and_reset_billing_cycle_nation")
     @patch("src.lambdas.nat_agent.handler.get_nb_tokens_by_nation")
-    def test_ids_from_lowercase_headers(
+    def test_body_nation_slug_is_ignored(
         self,
         mock_get_tokens: MagicMock,
         mock_billing: MagicMock,
         mock_rate: MagicMock,
         mock_verify: MagicMock,
     ) -> None:
-        """Test that lowercase headers are honored for user_id and nation_slug."""
+        """A nation_slug in the request body cannot override the token claim."""
         mock_get_tokens.return_value = None
 
         event = create_api_event(
-            body={"query": "test query"},
-            headers={
-                "x-nat-user-id": TEST_USER_ID,
-                "x-nat-nation-slug": TEST_NATION_SLUG,
-            },
+            body={"query": "test query", "nation_slug": "other-nation"},
+            headers={"Authorization": bearer(TEST_USER_ID, TEST_NATION_SLUG)},
         )
         response = handler(event, None)
 
@@ -609,10 +667,10 @@ class TestHandler:
         mock_get_tokens.assert_not_called()
 
     def test_cors_headers_present(self) -> None:
-        """Test that CORS headers advertise the nation slug header."""
+        """Test that CORS headers advertise the Authorization header."""
         event = create_api_event(body=None)
         response = handler(event, None)
 
         assert "Access-Control-Allow-Origin" in response["headers"]
         assert response["headers"]["Access-Control-Allow-Origin"] == "*"
-        assert "X-Nat-Nation-Slug" in response["headers"]["Access-Control-Allow-Headers"]
+        assert "Authorization" in response["headers"]["Access-Control-Allow-Headers"]

--- a/tests/test_nat_agent_streaming.py
+++ b/tests/test_nat_agent_streaming.py
@@ -17,6 +17,7 @@ from src.lambdas.nat_agent_streaming.handler import (
     get_nb_tokens,
     get_user_info,
     handler,
+    authenticated_body,
     process_streaming_request,
     _get_undo_instruction,
     SSE_EVENT_TEXT,
@@ -25,6 +26,7 @@ from src.lambdas.nat_agent_streaming.handler import (
     SSE_EVENT_ERROR,
     SSE_EVENT_DONE,
 )
+from src.lambdas.shared.session_token import mint_session_token
 
 
 def run_async(coro: Any) -> Any:
@@ -36,8 +38,19 @@ def run_async(coro: Any) -> Any:
 TEST_USER_ID = "user-test-12345"
 TEST_TENANT_ID = "tenant-test-67890"
 TEST_NB_SLUG = "testnation"
+TEST_NATION_SLUG = "testnation"
 TEST_NB_TOKEN = "nb_test_token_abc123"
 TEST_API_KEY = "sk-ant-test-key"
+TEST_JWT_SECRET = "test-session-secret"
+
+
+def bearer(
+    user_id: str = TEST_USER_ID,
+    nation_slug: str = TEST_NATION_SLUG,
+    secret: str = TEST_JWT_SECRET,
+) -> str:
+    """Build an `Authorization: Bearer <jwt>` header value for tests."""
+    return f"Bearer {mint_session_token(user_id, nation_slug, secret)}"
 
 
 def create_lambda_url_event(
@@ -451,6 +464,15 @@ class TestProcessStreamingRequest:
 class TestHandler:
     """Tests for the main Lambda handler."""
 
+    @pytest.fixture(autouse=True)
+    def _patch_session_secret(self) -> Any:
+        """Use a deterministic signing secret for session-token verification."""
+        with patch(
+            "src.lambdas.shared.session_token.get_session_secret",
+            return_value=TEST_JWT_SECRET,
+        ):
+            yield
+
     def test_empty_body(self) -> None:
         """Test that empty request body returns 400."""
         event = create_lambda_url_event(body=None)
@@ -487,7 +509,10 @@ class TestHandler:
         )
         mock_asyncio.get_event_loop.return_value = mock_event_loop
 
-        event = create_lambda_url_event(body={"user_id": TEST_USER_ID})
+        event = create_lambda_url_event(
+            body={"user_id": TEST_USER_ID},
+            headers={"Authorization": bearer()},
+        )
         response = handler(event, None)
 
         assert response["headers"]["Content-Type"] == "text/event-stream"
@@ -521,10 +546,13 @@ class TestHandler:
         mock_event_loop.run_until_complete.return_value = expected_events
         mock_asyncio.get_event_loop.return_value = mock_event_loop
 
-        event = create_lambda_url_event(body={
-            "query": "test query",
-            "user_id": TEST_USER_ID,
-        })
+        event = create_lambda_url_event(
+            body={
+                "query": "test query",
+                "user_id": TEST_USER_ID,
+            },
+            headers={"Authorization": bearer()},
+        )
         response = handler(event, None)
 
         assert response["statusCode"] == 200
@@ -552,7 +580,7 @@ class TestHandler:
             event = {
                 "body": encoded_body,
                 "isBase64Encoded": True,
-                "headers": {},
+                "headers": {"Authorization": bearer()},
             }
 
             with patch("src.lambdas.nat_agent_streaming.handler.asyncio") as mock_asyncio:
@@ -714,3 +742,65 @@ class TestUndoFunctionality:
             original_tool_name="create_signup"
         )
         assert result == "This action cannot be undone"
+
+
+class TestStreamingAuthentication:
+    """Authentication / IDOR-closure tests for the streaming entrypoint."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_session_secret(self) -> Any:
+        with patch(
+            "src.lambdas.shared.session_token.get_session_secret",
+            return_value=TEST_JWT_SECRET,
+        ):
+            yield
+
+    def test_missing_token_returns_401(self) -> None:
+        """No Authorization header -> 401 before any work."""
+        event = create_lambda_url_event(
+            body={"query": "hi", "user_id": TEST_USER_ID},
+            headers={},
+        )
+        response = handler(event, None)
+        assert response["statusCode"] == 401
+        body = json.loads(response["body"])
+        assert body["error_code"] == "MISSING_TOKEN"
+
+    def test_forged_token_returns_401(self) -> None:
+        """A token signed with the wrong secret -> 401."""
+        event = create_lambda_url_event(
+            body={"query": "hi"},
+            headers={"Authorization": bearer(secret="attacker-secret")},
+        )
+        response = handler(event, None)
+        assert response["statusCode"] == 401
+
+    def test_expired_token_returns_401(self) -> None:
+        expired = mint_session_token(
+            TEST_USER_ID, TEST_NATION_SLUG, TEST_JWT_SECRET, ttl_seconds=-5
+        )
+        event = create_lambda_url_event(
+            body={"query": "hi"},
+            headers={"Authorization": f"Bearer {expired}"},
+        )
+        response = handler(event, None)
+        assert response["statusCode"] == 401
+        body = json.loads(response["body"])
+        assert body["error_code"] == "TOKEN_EXPIRED"
+
+    def test_authenticated_body_overrides_client_identity(self) -> None:
+        """authenticated_body derives identity from the token, not the body."""
+        event = create_lambda_url_event(
+            body={"query": "hi"},
+            headers={"Authorization": bearer("real-user", "real-nation")},
+        )
+        body = {
+            "query": "hi",
+            "user_id": "attacker",
+            "nation_slug": "victim-nation",
+        }
+        result = authenticated_body(event, body)
+        assert result["user_id"] == "real-user"
+        assert result["nation_slug"] == "real-nation"
+        # The original body dict is not mutated.
+        assert body["nation_slug"] == "victim-nation"

--- a/tests/test_nb_oauth_callback.py
+++ b/tests/test_nb_oauth_callback.py
@@ -388,6 +388,10 @@ class TestHandler:
                 "src.lambdas.nb_oauth_callback.handler.get_secret",
                 side_effect=[TEST_CLIENT_ID, TEST_CLIENT_SECRET],
             ),
+            patch(
+                "src.lambdas.nb_oauth_callback.handler.get_session_secret",
+                return_value="test-session-secret",
+            ),
             patch("urllib3.PoolManager", return_value=mock_http),
         ):
             response = handler(event, None)
@@ -395,6 +399,8 @@ class TestHandler:
         assert response["statusCode"] == 302
         assert "connected" in response["headers"]["Location"].lower()
         assert TEST_USER_ID in response["headers"]["Location"]
+        # A signed session token is returned to the extension via the fragment.
+        assert "#session_token=" in response["headers"]["Location"]
 
         # Verify nation connection record was created/updated
         assert len(nations_table.put_calls) == 1

--- a/tests/test_session_token.py
+++ b/tests/test_session_token.py
@@ -1,0 +1,192 @@
+"""
+Unit tests for the stdlib HS256 session-token (JWT) helper.
+
+Covers minting, verification, expiry, signature tampering, forged secrets,
+malformed input, bearer extraction, and the request-authentication convenience.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.lambdas.shared.session_token import (
+    SessionContext,
+    SessionTokenError,
+    authenticate_request,
+    extract_bearer_token,
+    get_session_secret,
+    mint_session_token,
+    reset_secret_cache,
+    verify_session_token,
+)
+
+SECRET = "unit-test-secret"
+USER_ID = "user-abc"
+NATION = "acme"
+
+
+class TestMintAndVerify:
+    def test_roundtrip_returns_claims(self) -> None:
+        token = mint_session_token(USER_ID, NATION, SECRET)
+        claims = verify_session_token(token, SECRET)
+        assert claims["user_id"] == USER_ID
+        assert claims["nation_slug"] == NATION
+        assert claims["exp"] > claims["iat"]
+
+    def test_token_has_three_segments(self) -> None:
+        token = mint_session_token(USER_ID, NATION, SECRET)
+        assert len(token.split(".")) == 3
+
+    def test_mint_requires_identity(self) -> None:
+        with pytest.raises(ValueError):
+            mint_session_token("", NATION, SECRET)
+        with pytest.raises(ValueError):
+            mint_session_token(USER_ID, "", SECRET)
+
+    def test_ttl_controls_expiry(self) -> None:
+        token = mint_session_token(USER_ID, NATION, SECRET, ttl_seconds=100, now=1000)
+        claims = verify_session_token(token, SECRET, now=1050)
+        assert claims["exp"] == 1100
+
+
+class TestVerifyFailures:
+    def test_wrong_secret_rejected(self) -> None:
+        token = mint_session_token(USER_ID, NATION, SECRET)
+        with pytest.raises(SessionTokenError) as exc:
+            verify_session_token(token, "different-secret")
+        assert exc.value.http_status == 401
+
+    def test_expired_token_rejected(self) -> None:
+        token = mint_session_token(USER_ID, NATION, SECRET, ttl_seconds=100, now=1000)
+        with pytest.raises(SessionTokenError) as exc:
+            verify_session_token(token, SECRET, now=2000)
+        assert exc.value.code == "TOKEN_EXPIRED"
+
+    def test_exactly_at_expiry_rejected(self) -> None:
+        token = mint_session_token(USER_ID, NATION, SECRET, ttl_seconds=100, now=1000)
+        with pytest.raises(SessionTokenError):
+            verify_session_token(token, SECRET, now=1100)
+
+    def test_tampered_payload_rejected(self) -> None:
+        token = mint_session_token(USER_ID, NATION, SECRET)
+        header, payload, sig = token.split(".")
+        flipped = "A" if payload[-1] != "A" else "B"
+        tampered = f"{header}.{payload[:-1]}{flipped}.{sig}"
+        with pytest.raises(SessionTokenError):
+            verify_session_token(tampered, SECRET)
+
+    def test_alg_none_attack_rejected(self) -> None:
+        # An attacker-crafted unsigned token must not be accepted.
+        import base64
+
+        def seg(data: dict[str, object]) -> str:
+            raw = json.dumps(data).encode()
+            return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+        forged = (
+            seg({"alg": "none", "typ": "JWT"})
+            + "."
+            + seg({"user_id": USER_ID, "nation_slug": NATION, "exp": 9999999999})
+            + "."
+        )
+        with pytest.raises(SessionTokenError):
+            verify_session_token(forged, SECRET)
+
+    def test_malformed_token_rejected(self) -> None:
+        with pytest.raises(SessionTokenError):
+            verify_session_token("not-a-jwt", SECRET)
+
+    def test_empty_token_rejected(self) -> None:
+        with pytest.raises(SessionTokenError) as exc:
+            verify_session_token("", SECRET)
+        assert exc.value.code == "MISSING_TOKEN"
+
+
+class TestExtractBearer:
+    def test_extracts_token(self) -> None:
+        assert extract_bearer_token({"Authorization": "Bearer abc.def.ghi"}) == "abc.def.ghi"
+
+    def test_case_insensitive_header_and_scheme(self) -> None:
+        assert extract_bearer_token({"authorization": "bearer xyz"}) == "xyz"
+
+    def test_missing_header_rejected(self) -> None:
+        with pytest.raises(SessionTokenError) as exc:
+            extract_bearer_token({})
+        assert exc.value.code == "MISSING_TOKEN"
+
+    def test_non_bearer_rejected(self) -> None:
+        with pytest.raises(SessionTokenError):
+            extract_bearer_token({"Authorization": "Basic abc"})
+
+    def test_empty_bearer_rejected(self) -> None:
+        with pytest.raises(SessionTokenError):
+            extract_bearer_token({"Authorization": "Bearer "})
+
+
+class TestAuthenticateRequest:
+    def test_returns_identity_from_claims(self) -> None:
+        token = mint_session_token(USER_ID, NATION, SECRET)
+        event = {"headers": {"Authorization": f"Bearer {token}"}}
+        ctx = authenticate_request(event, secret=SECRET)
+        assert isinstance(ctx, SessionContext)
+        assert ctx.user_id == USER_ID
+        assert ctx.nation_slug == NATION
+
+    def test_cross_nation_token_cannot_claim_another_nation(self) -> None:
+        # A token for nation A yields nation A regardless of any other input.
+        token = mint_session_token(USER_ID, "nation-a", SECRET)
+        event = {
+            "headers": {
+                "Authorization": f"Bearer {token}",
+                "X-Nat-Nation-Slug": "nation-b",
+            }
+        }
+        ctx = authenticate_request(event, secret=SECRET)
+        assert ctx.nation_slug == "nation-a"
+
+    def test_missing_token_raises(self) -> None:
+        with pytest.raises(SessionTokenError):
+            authenticate_request({"headers": {}}, secret=SECRET)
+
+
+class TestGetSessionSecret:
+    def setup_method(self) -> None:
+        reset_secret_cache()
+
+    def teardown_method(self) -> None:
+        reset_secret_cache()
+
+    def test_plain_string_secret(self) -> None:
+        client = MagicMock()
+        client.get_secret_value.return_value = {"SecretString": "plain-secret"}
+        with patch(
+            "src.lambdas.shared.session_token.get_secrets_manager_client",
+            return_value=client,
+        ):
+            assert get_session_secret() == "plain-secret"
+
+    def test_json_secret_field(self) -> None:
+        client = MagicMock()
+        client.get_secret_value.return_value = {
+            "SecretString": json.dumps({"secret": "json-secret"})
+        }
+        with patch(
+            "src.lambdas.shared.session_token.get_secrets_manager_client",
+            return_value=client,
+        ):
+            assert get_session_secret() == "json-secret"
+
+    def test_secret_is_cached(self) -> None:
+        client = MagicMock()
+        client.get_secret_value.return_value = {"SecretString": "cached"}
+        with patch(
+            "src.lambdas.shared.session_token.get_secrets_manager_client",
+            return_value=client,
+        ):
+            get_session_secret()
+            get_session_secret()
+        # Only the first call hits Secrets Manager.
+        assert client.get_secret_value.call_count == 1


### PR DESCRIPTION
**⚠️ DRAFT — backend half of #10 only. Do NOT merge alone: it's a coordinated breaking change.**

Partial implementation of the login-based session-token decision (#10, epic #18). Recovered from a pr-driver run that crashed before committing; the agent's own adversarial self-review did **not** run, so this needs a real review.

### What's done (backend)
- `src/lambdas/shared/session_token.py` — hand-rolled HS256 JWT (no extra deps): mint + verify, claims `{user_id, nation_slug, exp}`, short TTL, secret from Secrets Manager (`nat/session-jwt-secret`)
- OAuth callback mints the token after storing NB tokens
- Both agent handlers verify the token and derive `user_id`/`nation_slug` from claims — **closes the IDOR** (a token for nation A can't touch nation B)
- Header trust removed: CORS `Allow-Headers` now `Authorization` (was `X-Nat-User-Id,X-Nat-Nation-Slug`)
- `infrastructure/template.yaml` references the new secret

### What's MISSING (blocks merge)
- **Extension half** — the extension must send `Authorization: Bearer <jwt>`, drop the `X-Nat-*` headers, store the token, and handle 401 by re-authenticating. Until then the extension breaks, because the backend now **hard-requires** the token.

### Verified independently
- `pytest -q` → **542 passed** (+28, incl. new `test_session_token.py`); `mypy src/` → clean
- Signature check uses `hmac.compare_digest` (constant-time); forged/expired/tampered tokens rejected

### Security review still needed
- Token lifetime + refresh/re-mint path (define & confirm)
- Token at rest in `chrome.storage` (XSS exposure) — acceptable? rotation?
- Secret provisioning in Secrets Manager at deploy

Sequencing: this and #11 (OAuth-callback CSRF) both touch `nb_oauth_callback` — coordinate.
