### PR TITLE
feat(security): validate nation_slug + idempotent Stripe webhook (fixes #13)

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -126,6 +126,32 @@ Resources:
         - Key: Project
           Value: nat
 
+  # StripeEventsTable - records processed Stripe webhook event IDs so duplicate
+  # deliveries (Stripe retries) are no-ops. TTL purges old markers automatically.
+  StripeEventsTable:
+    Type: AWS::DynamoDB::Table
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      TableName: !Sub 'nat-stripe-events-${Environment}'
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: event_id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: event_id
+          KeyType: HASH
+      TimeToLiveSpecification:
+        AttributeName: expires_at
+        Enabled: true
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      Tags:
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Project
+          Value: nat
+
   # =============================================================================
   # IAM Roles
   # =============================================================================
@@ -163,6 +189,8 @@ Resources:
                   - !Sub '${TenantsTable.Arn}/index/*'
                   - !GetAtt UsersTable.Arn
                   - !Sub '${UsersTable.Arn}/index/*'
+                  - !GetAtt StripeEventsTable.Arn
+                  - !Sub '${StripeEventsTable.Arn}/index/*'
         - PolicyName: SecretsManagerAccess
           PolicyDocument:
             Version: '2012-10-17'
@@ -282,6 +310,7 @@ Resources:
           NATIONS_TABLE: !Ref NationsTable
           TENANTS_TABLE: !Ref TenantsTable
           USERS_TABLE: !Ref UsersTable
+          STRIPE_EVENTS_TABLE: !Ref StripeEventsTable
           STRIPE_WEBHOOK_SECRET_NAME: !Sub 'nat/stripe-webhook-secret-${Environment}'
       Tags:
         - Key: Environment
@@ -871,6 +900,18 @@ Outputs:
     Value: !GetAtt UsersTable.Arn
     Export:
       Name: !Sub '${AWS::StackName}-UsersTableArn'
+
+  StripeEventsTableName:
+    Description: Name of the Stripe events idempotency DynamoDB table
+    Value: !Ref StripeEventsTable
+    Export:
+      Name: !Sub '${AWS::StackName}-StripeEventsTableName'
+
+  StripeEventsTableArn:
+    Description: ARN of the Stripe events idempotency DynamoDB table
+    Value: !GetAtt StripeEventsTable.Arn
+    Export:
+      Name: !Sub '${AWS::StackName}-StripeEventsTableArn'
 
   LambdaExecutionRoleArn:
     Description: ARN of the Lambda execution role

--- a/src/lambdas/nat_agent/handler.py
+++ b/src/lambdas/nat_agent/handler.py
@@ -38,6 +38,11 @@ except ModuleNotFoundError:  # pragma: no cover - exercised only in Lambda
         authenticate_request,
     )
 
+try:  # Resolve in both pytest (repo root) and flattened Lambda packages.
+    from src.lambdas.shared.validation import is_valid_nation_slug
+except ModuleNotFoundError:  # pragma: no cover - exercised only in Lambda
+    from shared.validation import is_valid_nation_slug  # type: ignore[no-redef]
+
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
@@ -372,6 +377,17 @@ def handler(event: dict[str, Any], context: Any) -> LambdaResponse:
 
         user_id = session.user_id
         nation_slug = session.nation_slug
+
+        # Defense in depth: the slug is token-attested (minted post-validation at
+        # OAuth connect), but it is interpolated into Secrets Manager / DynamoDB
+        # lookups, so reject a malformed value rather than build a bad key.
+        if not is_valid_nation_slug(nation_slug):
+            logger.error(f"Invalid nation_slug in session token: {nation_slug!r}")
+            return {
+                "statusCode": 400,
+                "body": json.dumps({"error": "Invalid nation_slug format"}),
+                "headers": headers,
+            }
 
         # Extract request payload (identity fields are ignored if present).
         query = body.get("query")

--- a/src/lambdas/nat_agent_streaming/handler.py
+++ b/src/lambdas/nat_agent_streaming/handler.py
@@ -40,6 +40,11 @@ except ModuleNotFoundError:  # pragma: no cover - exercised only in Lambda
         authenticate_request,
     )
 
+try:  # Resolve in both pytest (repo root) and flattened Lambda packages.
+    from src.lambdas.shared.validation import is_valid_nation_slug
+except ModuleNotFoundError:  # pragma: no cover - exercised only in Lambda
+    from shared.validation import is_valid_nation_slug  # type: ignore[no-redef]
+
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
@@ -512,6 +517,17 @@ async def process_streaming_request(body: dict[str, Any]) -> AsyncGenerator[str,
     if not nation_slug:
         yield format_sse_event(SSE_EVENT_ERROR, {
             "error": "Missing required field: nation_slug",
+            "error_code": "BAD_REQUEST",
+        })
+        return
+
+    # Defense in depth: the slug is token-attested (minted post-validation at
+    # OAuth connect), but it is interpolated into Secrets Manager / DynamoDB
+    # lookups, so reject a malformed value rather than build a bad key.
+    if not is_valid_nation_slug(nation_slug):
+        logger.error(f"Invalid nation_slug in session token: {nation_slug!r}")
+        yield format_sse_event(SSE_EVENT_ERROR, {
+            "error": "Invalid nation_slug format",
             "error_code": "BAD_REQUEST",
         })
         return

--- a/src/lambdas/nb_oauth_callback/handler.py
+++ b/src/lambdas/nb_oauth_callback/handler.py
@@ -58,7 +58,7 @@ ERROR_REDIRECT_URL = os.environ.get(
 # host ``https://{slug}.nationbuilder.com``. Reject malformed values before
 # either is constructed. Mirrors shared.validation.NATION_SLUG_PATTERN (this
 # Lambda is packaged without shared/, so the pattern is inlined).
-NATION_SLUG_PATTERN = re.compile(r"^[a-z0-9-]{1,63}$")
+NATION_SLUG_PATTERN = re.compile(r"^[a-z0-9-]{1,63}\Z")
 
 
 def is_valid_nation_slug(slug: Any) -> bool:

--- a/src/lambdas/nb_oauth_callback/handler.py
+++ b/src/lambdas/nb_oauth_callback/handler.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 from datetime import datetime, timezone
 from typing import Any, TypedDict
 from urllib.parse import parse_qs, urlencode
@@ -50,6 +51,19 @@ SUCCESS_REDIRECT_URL = os.environ.get(
 ERROR_REDIRECT_URL = os.environ.get(
     "ERROR_REDIRECT_URL", "https://natassistant.com/connection-error"
 )
+
+# The nation slug arrives in the (client-supplied) OAuth ``state`` and is the
+# most security-sensitive entry point: it is interpolated into the Secrets
+# Manager path ``nat/nation/{slug}/nb-tokens`` and the NationBuilder token URL
+# host ``https://{slug}.nationbuilder.com``. Reject malformed values before
+# either is constructed. Mirrors shared.validation.NATION_SLUG_PATTERN (this
+# Lambda is packaged without shared/, so the pattern is inlined).
+NATION_SLUG_PATTERN = re.compile(r"^[a-z0-9-]{1,63}$")
+
+
+def is_valid_nation_slug(slug: Any) -> bool:
+    """Return True if *slug* is a non-empty, well-formed nation slug."""
+    return isinstance(slug, str) and NATION_SLUG_PATTERN.match(slug) is not None
 
 
 class LambdaResponse(TypedDict):
@@ -432,6 +446,14 @@ def handler(event: dict[str, Any], context: Any) -> LambdaResponse:
         if not user_id or not nb_slug or not redirect_uri:
             logger.error("State missing required fields")
             error_url = f"{ERROR_REDIRECT_URL}?error=invalid_state"
+            return create_redirect_response(error_url)
+
+        # Reject a malformed slug before it reaches Secrets Manager / the NB token
+        # URL. This endpoint is a browser OAuth redirect, so a rejected slug is
+        # surfaced as an error redirect rather than a 400 JSON body.
+        if not is_valid_nation_slug(nb_slug):
+            logger.error(f"Invalid nation_slug in OAuth state: {nb_slug!r}")
+            error_url = f"{ERROR_REDIRECT_URL}?error=invalid_nation"
             return create_redirect_response(error_url)
 
         # Extract optional email from state for admin user creation

--- a/src/lambdas/shared/validation.py
+++ b/src/lambdas/shared/validation.py
@@ -20,7 +20,7 @@ from typing import Any
 
 # NationBuilder slugs are lowercase alphanumeric plus hyphen. The 63-char ceiling
 # matches a DNS label (slugs appear as the subdomain of *.nationbuilder.com).
-NATION_SLUG_PATTERN = re.compile(r"^[a-z0-9-]{1,63}$")
+NATION_SLUG_PATTERN = re.compile(r"^[a-z0-9-]{1,63}\Z")
 
 
 class InvalidNationSlugError(ValueError):

--- a/src/lambdas/shared/validation.py
+++ b/src/lambdas/shared/validation.py
@@ -1,0 +1,43 @@
+"""
+Input validation helpers shared across Lambda handlers.
+
+The canonical home for ``nation_slug`` format validation. A nation slug flows
+directly into DynamoDB keys, Secrets Manager secret names
+(``nat/nation/{slug}/nb-tokens``) and NationBuilder API URLs
+(``https://{slug}.nationbuilder.com``), so every entry point that accepts one
+must reject malformed values before they are used.
+
+Only the Lambdas that bundle ``shared/`` at deploy time (the agent handlers)
+import this module. The standalone handlers (stripe_checkout, stripe_webhook,
+nb_oauth_callback) are packaged without ``shared/`` and inline an identical
+``NATION_SLUG_PATTERN`` instead.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# NationBuilder slugs are lowercase alphanumeric plus hyphen. The 63-char ceiling
+# matches a DNS label (slugs appear as the subdomain of *.nationbuilder.com).
+NATION_SLUG_PATTERN = re.compile(r"^[a-z0-9-]{1,63}$")
+
+
+class InvalidNationSlugError(ValueError):
+    """Raised when a nation_slug does not match the required format."""
+
+
+def is_valid_nation_slug(slug: Any) -> bool:
+    """Return True if *slug* is a non-empty, well-formed nation slug."""
+    return isinstance(slug, str) and NATION_SLUG_PATTERN.match(slug) is not None
+
+
+def validate_nation_slug(slug: Any) -> str:
+    """Return *slug* unchanged if valid, else raise :class:`InvalidNationSlugError`."""
+    if not is_valid_nation_slug(slug):
+        raise InvalidNationSlugError(
+            f"Invalid nation_slug format: {slug!r} (must match ^[a-z0-9-]{{1,63}}$)"
+        )
+    # is_valid_nation_slug guarantees a str; assert narrows it for the type checker.
+    assert isinstance(slug, str)
+    return slug

--- a/src/lambdas/stripe_checkout/handler.py
+++ b/src/lambdas/stripe_checkout/handler.py
@@ -23,7 +23,7 @@ logger.setLevel(logging.INFO)
 # metadata and later used by the webhook as a DynamoDB key. Mirrors
 # shared.validation.NATION_SLUG_PATTERN (this Lambda is packaged without
 # shared/, so the pattern is inlined).
-NATION_SLUG_PATTERN = re.compile(r"^[a-z0-9-]{1,63}$")
+NATION_SLUG_PATTERN = re.compile(r"^[a-z0-9-]{1,63}\Z")
 
 
 def is_valid_nation_slug(slug: Any) -> bool:

--- a/src/lambdas/stripe_checkout/handler.py
+++ b/src/lambdas/stripe_checkout/handler.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 from typing import Any, TypedDict
 
 import boto3
@@ -17,6 +18,17 @@ from botocore.exceptions import ClientError
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
+
+# nation_slug is validated here because it is forwarded to Stripe as checkout
+# metadata and later used by the webhook as a DynamoDB key. Mirrors
+# shared.validation.NATION_SLUG_PATTERN (this Lambda is packaged without
+# shared/, so the pattern is inlined).
+NATION_SLUG_PATTERN = re.compile(r"^[a-z0-9-]{1,63}$")
+
+
+def is_valid_nation_slug(slug: Any) -> bool:
+    """Return True if *slug* is a non-empty, well-formed nation slug."""
+    return isinstance(slug, str) and NATION_SLUG_PATTERN.match(slug) is not None
 
 # Environment variables
 STRIPE_SECRET_KEY_NAME = os.environ.get(
@@ -171,6 +183,15 @@ def handler(event: dict[str, Any], context: Any) -> LambdaResponse:
             return {
                 "statusCode": 400,
                 "body": json.dumps({"error": "Missing required field: nation_slug"}),
+                "headers": headers,
+            }
+
+        if not is_valid_nation_slug(nation_slug):
+            return {
+                "statusCode": 400,
+                "body": json.dumps({
+                    "error": "Invalid nation_slug format (must match ^[a-z0-9-]{1,63}$)"
+                }),
                 "headers": headers,
             }
 

--- a/src/lambdas/stripe_webhook/handler.py
+++ b/src/lambdas/stripe_webhook/handler.py
@@ -14,6 +14,7 @@ import hmac
 import json
 import logging
 import os
+import re
 import time
 import uuid
 from datetime import datetime, timezone
@@ -29,9 +30,27 @@ logger.setLevel(logging.INFO)
 NATIONS_TABLE = os.environ.get("NATIONS_TABLE", "nat-nations-dev")
 TENANTS_TABLE = os.environ.get("TENANTS_TABLE", "nat-tenants-dev")
 USERS_TABLE = os.environ.get("USERS_TABLE", "nat-users-dev")
+# Table of processed Stripe event IDs (with TTL) used for webhook idempotency.
+STRIPE_EVENTS_TABLE = os.environ.get("STRIPE_EVENTS_TABLE", "nat-stripe-events-dev")
 STRIPE_WEBHOOK_SECRET_NAME = os.environ.get(
     "STRIPE_WEBHOOK_SECRET_NAME", "nat/stripe-webhook-secret"
 )
+
+# Stripe retries a delivery for up to ~3 days until it gets a 2xx. We keep each
+# processed event ID a bit beyond that window so replays are reliably deduped,
+# then let DynamoDB TTL purge the marker.
+EVENT_TTL_SECONDS = int(os.environ.get("STRIPE_EVENT_TTL_SECONDS", str(7 * 24 * 3600)))
+
+# nation_slug is validated wherever it is accepted because it flows into
+# DynamoDB keys, Secrets Manager names, and NationBuilder API URLs. Mirrors
+# shared.validation.NATION_SLUG_PATTERN (this Lambda is packaged without
+# shared/, so the pattern is inlined).
+NATION_SLUG_PATTERN = re.compile(r"^[a-z0-9-]{1,63}$")
+
+
+def is_valid_nation_slug(slug: Any) -> bool:
+    """Return True if *slug* is a non-empty, well-formed nation slug."""
+    return isinstance(slug, str) and NATION_SLUG_PATTERN.match(slug) is not None
 
 # NEW PRICING MODEL: Nation-level plans
 # Nat: $29/mo, 500 queries/month
@@ -143,6 +162,66 @@ def get_dynamodb_resource() -> Any:
     return boto3.resource("dynamodb")
 
 
+def record_event_id(event_id: str) -> bool:
+    """
+    Atomically record a processed Stripe event ID for idempotency.
+
+    Uses a conditional put so concurrent or retried deliveries of the same event
+    race on a single write: the first caller wins and should process the event;
+    every later caller sees the existing marker and skips. This is what prevents
+    ``handle_checkout_completed`` (and the other handlers) from double-writing
+    when Stripe legitimately redelivers an event.
+
+    Returns:
+        True if this call recorded the ID (caller should process the event),
+        False if the ID was already present (duplicate -- caller should no-op).
+    """
+    if not event_id:
+        # Genuine Stripe events always carry an ``id``. If one is missing we
+        # cannot dedupe, so process rather than silently drop the event.
+        logger.warning("Stripe event has no id; cannot dedupe, processing anyway")
+        return True
+
+    dynamodb = get_dynamodb_resource()
+    events_table = dynamodb.Table(STRIPE_EVENTS_TABLE)
+    expires_at = int(time.time()) + EVENT_TTL_SECONDS
+
+    try:
+        events_table.put_item(
+            Item={
+                "event_id": event_id,
+                "processed_at": datetime.now(timezone.utc).isoformat(),
+                "expires_at": expires_at,
+            },
+            ConditionExpression="attribute_not_exists(event_id)",
+        )
+        return True
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            logger.info(f"Duplicate Stripe event {event_id}; skipping reprocessing")
+            return False
+        raise
+
+
+def forget_event_id(event_id: str) -> None:
+    """
+    Best-effort removal of an event marker after processing failed.
+
+    If a handler raises *after* the marker was written, a subsequent Stripe retry
+    would otherwise be treated as a duplicate and dropped. Removing the marker
+    lets the retry reprocess the event. Never raises: a cleanup failure must not
+    mask the original processing error.
+    """
+    if not event_id:
+        return
+    try:
+        dynamodb = get_dynamodb_resource()
+        events_table = dynamodb.Table(STRIPE_EVENTS_TABLE)
+        events_table.delete_item(Key={"event_id": event_id})
+    except Exception as e:  # noqa: BLE001 - best effort cleanup
+        logger.warning(f"Failed to remove event marker {event_id}: {e}")
+
+
 def get_plan_from_price(price_id: str) -> str:
     """Map Stripe price ID to plan name."""
     # Default to extracting plan name from price ID if not in mapping
@@ -188,6 +267,14 @@ def handle_checkout_completed(session: dict[str, Any]) -> None:
         # This is critical - we cannot proceed without nation_slug
         # In production, consider alerting on this error
         raise ValueError(f"Missing nation_slug in checkout metadata for customer {customer_id}")
+
+    if not is_valid_nation_slug(nation_slug):
+        # A malformed slug would be written straight into the nation primary key;
+        # reject it rather than persist a corrupt record.
+        logger.error(f"Invalid nation_slug in checkout metadata: {nation_slug!r}")
+        raise ValueError(
+            f"Invalid nation_slug format in checkout metadata for customer {customer_id}"
+        )
 
     # If subscription exists, we'll get more details from subscription.updated
     # For now, create the nation with basic info
@@ -384,6 +471,16 @@ def handle_subscription_deleted(subscription: dict[str, Any]) -> None:
         raise
 
 
+# Maps Stripe event types to their handlers. Used both to dispatch and to decide
+# which event types are worth recording for idempotency (others are acked and
+# ignored without a DynamoDB write).
+EVENT_HANDLERS = {
+    "checkout.session.completed": handle_checkout_completed,
+    "customer.subscription.updated": handle_subscription_updated,
+    "customer.subscription.deleted": handle_subscription_deleted,
+}
+
+
 def handler(event: dict[str, Any], context: Any) -> LambdaResponse:
     """
     Lambda handler for Stripe webhooks.
@@ -422,18 +519,38 @@ def handler(event: dict[str, Any], context: Any) -> LambdaResponse:
         webhook_event: WebhookEvent = json.loads(body)
         event_type = webhook_event.get("type", "")
         event_data = webhook_event.get("data", {}).get("object", {})
+        event_id = webhook_event.get("id", "")
 
-        logger.info(f"Processing webhook event: {event_type}")
+        logger.info(f"Processing webhook event: {event_type} ({event_id})")
 
-        # Route to appropriate handler
-        if event_type == "checkout.session.completed":
-            handle_checkout_completed(event_data)
-        elif event_type == "customer.subscription.updated":
-            handle_subscription_updated(event_data)
-        elif event_type == "customer.subscription.deleted":
-            handle_subscription_deleted(event_data)
-        else:
+        # Short-circuit event types we don't act on. Acknowledging them with 200
+        # (so Stripe stops retrying) without recording an idempotency marker
+        # keeps the events table free of the many types we ignore.
+        if event_type not in EVENT_HANDLERS:
             logger.info(f"Ignoring unhandled event type: {event_type}")
+            return {
+                "statusCode": 200,
+                "body": json.dumps({"received": True}),
+                "headers": headers,
+            }
+
+        # Idempotency gate: record the event ID before doing any work. If we have
+        # already processed this delivery (Stripe retry, or near-simultaneous
+        # duplicate deliveries), skip so handlers do not double-write.
+        if not record_event_id(event_id):
+            return {
+                "statusCode": 200,
+                "body": json.dumps({"received": True, "duplicate": True}),
+                "headers": headers,
+            }
+
+        try:
+            EVENT_HANDLERS[event_type](event_data)
+        except Exception:
+            # Processing failed after the marker was written; remove it so a
+            # Stripe retry can reprocess instead of being deduped away.
+            forget_event_id(event_id)
+            raise
 
         return {
             "statusCode": 200,
@@ -446,6 +563,14 @@ def handler(event: dict[str, Any], context: Any) -> LambdaResponse:
         return {
             "statusCode": 400,
             "body": json.dumps({"error": "Invalid JSON"}),
+            "headers": headers,
+        }
+    except ValueError as e:
+        # Raised by handlers for malformed payloads (e.g. invalid nation_slug).
+        logger.error(f"Webhook validation error: {e}")
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"error": str(e)}),
             "headers": headers,
         }
     except ClientError as e:

--- a/src/lambdas/stripe_webhook/handler.py
+++ b/src/lambdas/stripe_webhook/handler.py
@@ -45,7 +45,7 @@ EVENT_TTL_SECONDS = int(os.environ.get("STRIPE_EVENT_TTL_SECONDS", str(7 * 24 * 
 # DynamoDB keys, Secrets Manager names, and NationBuilder API URLs. Mirrors
 # shared.validation.NATION_SLUG_PATTERN (this Lambda is packaged without
 # shared/, so the pattern is inlined).
-NATION_SLUG_PATTERN = re.compile(r"^[a-z0-9-]{1,63}$")
+NATION_SLUG_PATTERN = re.compile(r"^[a-z0-9-]{1,63}\Z")
 
 
 def is_valid_nation_slug(slug: Any) -> bool:

--- a/tests/integration/test_stripe_webhook_integration.py
+++ b/tests/integration/test_stripe_webhook_integration.py
@@ -19,6 +19,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+from botocore.exceptions import ClientError
 
 from src.lambdas.stripe_webhook.handler import (
     PLAN_QUERY_LIMITS,
@@ -75,18 +76,46 @@ class MockDynamoDBTable:
                     self._items[key] = item.copy()
         self.put_calls: list[dict[str, Any]] = []
         self.update_calls: list[dict[str, Any]] = []
+        self.delete_calls: list[dict[str, Any]] = []
         self.query_calls: list[dict[str, Any]] = []
         self.query_results: list[dict[str, Any]] = []
 
     @staticmethod
     def _key(data: dict[str, Any]) -> Any:
-        return data.get("nation_slug") or data.get("tenant_id") or data.get("user_id")
+        return (
+            data.get("nation_slug")
+            or data.get("tenant_id")
+            or data.get("user_id")
+            or data.get("event_id")
+        )
 
-    def put_item(self, Item: dict[str, Any]) -> None:
+    def put_item(
+        self,
+        Item: dict[str, Any],
+        ConditionExpression: str | None = None,
+    ) -> None:
         key = self._key(Item)
+        # Simulate a conditional put (idempotency marker): fail if it exists.
+        if ConditionExpression and "attribute_not_exists" in ConditionExpression:
+            if key is not None and key in self._items:
+                raise ClientError(
+                    {
+                        "Error": {
+                            "Code": "ConditionalCheckFailedException",
+                            "Message": "The conditional request failed",
+                        }
+                    },
+                    "PutItem",
+                )
         if key:
             self._items[key] = Item.copy()
         self.put_calls.append(Item)
+
+    def delete_item(self, Key: dict[str, Any]) -> None:
+        key = self._key(Key)
+        if key is not None and key in self._items:
+            del self._items[key]
+        self.delete_calls.append(Key)
 
     def update_item(
         self,
@@ -129,14 +158,22 @@ class MockDynamoDBTable:
 class MockDynamoDBResource:
     """Mock DynamoDB resource.
 
-    The webhook handler operates exclusively on the NationsTable, so a single
-    backing table is returned regardless of the requested table name.
+    Routes the Stripe events idempotency table to a dedicated backing table so
+    event markers don't pollute nation-record assertions; everything else
+    resolves to the NationsTable.
     """
 
-    def __init__(self, nations_table: MockDynamoDBTable) -> None:
+    def __init__(
+        self,
+        nations_table: MockDynamoDBTable,
+        events_table: MockDynamoDBTable | None = None,
+    ) -> None:
         self.nations_table = nations_table
+        self.events_table = events_table or MockDynamoDBTable()
 
     def Table(self, name: str) -> MockDynamoDBTable:
+        if "stripe-events" in name:
+            return self.events_table
         return self.nations_table
 
 
@@ -236,7 +273,7 @@ class TestCheckoutCompletedIntegration:
         """Test checkout applies the correct query limit per plan for an
         already-existing nation (the plan/limit are set on the update path)."""
         for plan in ["starter", "team", "org"]:
-            nation_slug = f"nation_{plan}"
+            nation_slug = f"nation-{plan}"
             nations_table = MockDynamoDBTable([
                 {"nation_slug": nation_slug, "stripe_customer_id": f"{TEST_CUSTOMER_ID}_{plan}"}
             ])

--- a/tests/test_nat_agent.py
+++ b/tests/test_nat_agent.py
@@ -335,6 +335,23 @@ class TestHandler:
         body = json.loads(response["body"])
         assert body["error_code"] == "MISSING_TOKEN"
 
+    def test_malformed_slug_in_token_returns_400(self) -> None:
+        """Defense in depth: a malformed slug in a validly-signed token is rejected.
+
+        The slug is interpolated into Secrets Manager / DynamoDB lookups, so even
+        a token-attested value is format-checked before use.
+        """
+        token = mint_session_token(TEST_USER_ID, "bad slug!", TEST_JWT_SECRET)
+        event = create_api_event(
+            body={"query": "test query"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        response = handler(event, None)
+
+        assert response["statusCode"] == 400
+        body = json.loads(response["body"])
+        assert "Invalid nation_slug" in body["error"]
+
     def test_forged_token_returns_401(self) -> None:
         """A token signed with the wrong secret is rejected with 401."""
         event = create_api_event(

--- a/tests/test_nb_oauth_callback.py
+++ b/tests/test_nb_oauth_callback.py
@@ -345,6 +345,36 @@ class TestHandler:
         assert response["statusCode"] == 302
         assert "error=invalid_state" in response["headers"]["Location"]
 
+    def test_invalid_nation_slug_redirects_to_error(self) -> None:
+        """A malformed slug in state is rejected before any token exchange.
+
+        The slug flows into the Secrets Manager path and the NationBuilder token
+        URL host, so a bad value (here containing a path-traversal segment) must
+        be rejected up front. This endpoint is a browser redirect, so rejection
+        is surfaced as an error redirect rather than a 400 body.
+        """
+        malicious_state = base64.urlsafe_b64encode(
+            json.dumps(
+                {
+                    "user_id": TEST_USER_ID,
+                    "nb_slug": "../../etc/passwd",
+                    "redirect_uri": TEST_REDIRECT_URI,
+                }
+            ).encode()
+        ).decode()
+
+        event = {
+            "queryStringParameters": {
+                "code": TEST_CODE,
+                "state": malicious_state,
+            },
+        }
+
+        response = handler(event, None)
+
+        assert response["statusCode"] == 302
+        assert "error=invalid_nation" in response["headers"]["Location"]
+
     def test_successful_oauth_flow(self) -> None:
         """Test successful OAuth flow end-to-end."""
         users_table = MockDynamoDBTable()

--- a/tests/test_stripe_checkout.py
+++ b/tests/test_stripe_checkout.py
@@ -289,6 +289,36 @@ class TestHandler:
         body = json.loads(response["body"])
         assert "Invalid plan" in body["error"]
 
+    def test_missing_nation_slug(self) -> None:
+        """Test error when nation_slug is missing."""
+        event: dict[str, Any] = {
+            "httpMethod": "POST",
+            "body": json.dumps({"plan": "nat"}),
+        }
+
+        response = handler(event, None)
+
+        assert response["statusCode"] == 400
+        body = json.loads(response["body"])
+        assert "Missing required field: nation_slug" in body["error"]
+
+    @pytest.mark.parametrize(
+        "bad_slug",
+        ["Bad Slug!", "UPPER", "under_score", "dots.here", "a/b", "a" * 64],
+    )
+    def test_invalid_nation_slug_returns_400(self, bad_slug: str) -> None:
+        """A malformed nation_slug is rejected with 400 before reaching Stripe."""
+        event: dict[str, Any] = {
+            "httpMethod": "POST",
+            "body": json.dumps({"plan": "nat", "nation_slug": bad_slug}),
+        }
+
+        response = handler(event, None)
+
+        assert response["statusCode"] == 400
+        body = json.loads(response["body"])
+        assert "Invalid nation_slug" in body["error"]
+
     def test_invalid_json_body(self) -> None:
         """Test error handling for invalid JSON body."""
         event: dict[str, Any] = {

--- a/tests/test_stripe_webhook.py
+++ b/tests/test_stripe_webhook.py
@@ -12,14 +12,18 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from botocore.exceptions import ClientError
 
 from src.lambdas.stripe_webhook.handler import (
     PLAN_QUERY_LIMITS,
+    forget_event_id,
     get_plan_from_price,
     handle_checkout_completed,
     handle_subscription_deleted,
     handle_subscription_updated,
     handler,
+    is_valid_nation_slug,
+    record_event_id,
     verify_stripe_signature,
 )
 
@@ -111,17 +115,46 @@ class MockDynamoDBTable:
         self.items: dict[str, dict[str, Any]] = {}
         self.put_calls: list[dict[str, Any]] = []
         self.update_calls: list[dict[str, Any]] = []
+        self.delete_calls: list[dict[str, Any]] = []
         self.query_results: list[dict[str, Any]] = []
 
     @staticmethod
     def _key(data: dict[str, Any]) -> Any:
-        return data.get("nation_slug") or data.get("tenant_id") or data.get("user_id")
+        return (
+            data.get("nation_slug")
+            or data.get("tenant_id")
+            or data.get("user_id")
+            or data.get("event_id")
+        )
 
-    def put_item(self, Item: dict[str, Any]) -> None:
+    def put_item(
+        self,
+        Item: dict[str, Any],
+        ConditionExpression: str | None = None,
+    ) -> None:
         key = self._key(Item)
+        # Simulate a conditional put (idempotency marker): fail if the item
+        # already exists, mirroring DynamoDB's ConditionalCheckFailedException.
+        if ConditionExpression and "attribute_not_exists" in ConditionExpression:
+            if key is not None and key in self.items:
+                raise ClientError(
+                    {
+                        "Error": {
+                            "Code": "ConditionalCheckFailedException",
+                            "Message": "The conditional request failed",
+                        }
+                    },
+                    "PutItem",
+                )
         if key:
             self.items[key] = Item
         self.put_calls.append(Item)
+
+    def delete_item(self, Key: dict[str, Any]) -> None:
+        key = self._key(Key)
+        if key is not None and key in self.items:
+            del self.items[key]
+        self.delete_calls.append(Key)
 
     def get_item(self, Key: dict[str, Any]) -> dict[str, Any]:
         key = self._key(Key)
@@ -154,14 +187,22 @@ class MockDynamoDBTable:
 class MockDynamoDBResource:
     """Mock DynamoDB resource for testing.
 
-    The webhook handler now operates exclusively on the NationsTable, so a
-    single backing table is sufficient regardless of the table name requested.
+    Routes by table name: the Stripe events idempotency table is backed by a
+    dedicated mock so event markers don't pollute nation-record assertions;
+    everything else resolves to the NationsTable.
     """
 
-    def __init__(self, nations_table: MockDynamoDBTable) -> None:
+    def __init__(
+        self,
+        nations_table: MockDynamoDBTable,
+        events_table: MockDynamoDBTable | None = None,
+    ) -> None:
         self.nations_table = nations_table
+        self.events_table = events_table or MockDynamoDBTable()
 
     def Table(self, name: str) -> MockDynamoDBTable:
+        if "stripe-events" in name:
+            return self.events_table
         return self.nations_table
 
 
@@ -479,6 +520,7 @@ class TestHandler:
         mock_resource = MockDynamoDBResource(nations_table)
 
         event_body = {
+            "id": "evt_lowercase",
             "type": "checkout.session.completed",
             "data": {
                 "object": {
@@ -510,3 +552,211 @@ class TestHandler:
             response = handler(lambda_event, None)
 
         assert response["statusCode"] == 200
+
+
+class TestNationSlugValidation:
+    """Tests for nation_slug format validation in the webhook."""
+
+    def test_is_valid_nation_slug_accepts_good_slugs(self) -> None:
+        assert is_valid_nation_slug("testnation")
+        assert is_valid_nation_slug("my-nation-123")
+        assert is_valid_nation_slug("a")
+        assert is_valid_nation_slug("a" * 63)
+
+    def test_is_valid_nation_slug_rejects_bad_slugs(self) -> None:
+        assert not is_valid_nation_slug("")
+        assert not is_valid_nation_slug("UPPER")
+        assert not is_valid_nation_slug("has space")
+        assert not is_valid_nation_slug("under_score")
+        assert not is_valid_nation_slug("dots.here")
+        assert not is_valid_nation_slug("slash/here")
+        assert not is_valid_nation_slug("a" * 64)
+        assert not is_valid_nation_slug(None)  # type: ignore[arg-type]
+
+    def test_handle_checkout_invalid_slug_raises(self) -> None:
+        """A malformed slug in checkout metadata must not be persisted."""
+        nations_table = MockDynamoDBTable()
+        mock_resource = MockDynamoDBResource(nations_table)
+
+        session = {
+            "customer": TEST_CUSTOMER_ID,
+            "subscription": TEST_SUBSCRIPTION_ID,
+            "metadata": {"plan": "nat", "nation_slug": "Bad Slug!"},
+        }
+
+        with patch(
+            "src.lambdas.stripe_webhook.handler.get_dynamodb_resource",
+            return_value=mock_resource,
+        ):
+            with pytest.raises(ValueError, match="Invalid nation_slug"):
+                handle_checkout_completed(session)
+
+        # Nothing written to the nations table.
+        assert len(nations_table.put_calls) == 0
+        assert len(nations_table.update_calls) == 0
+
+    def test_handler_invalid_slug_returns_400(self) -> None:
+        """End-to-end: an invalid slug surfaces as a 400 from the handler."""
+        nations_table = MockDynamoDBTable()
+        mock_resource = MockDynamoDBResource(nations_table)
+
+        event_body = {
+            "id": "evt_badslug",
+            "type": "checkout.session.completed",
+            "data": {
+                "object": {
+                    "customer": TEST_CUSTOMER_ID,
+                    "subscription": TEST_SUBSCRIPTION_ID,
+                    "metadata": {"nation_slug": "Bad Slug!"},
+                }
+            },
+        }
+        body = json.dumps(event_body)
+        signature = create_stripe_signature(body, TEST_WEBHOOK_SECRET)
+        lambda_event = {"body": body, "headers": {"Stripe-Signature": signature}}
+
+        with (
+            patch(
+                "src.lambdas.stripe_webhook.handler.get_stripe_webhook_secret",
+                return_value=TEST_WEBHOOK_SECRET,
+            ),
+            patch(
+                "src.lambdas.stripe_webhook.handler.get_dynamodb_resource",
+                return_value=mock_resource,
+            ),
+        ):
+            response = handler(lambda_event, None)
+
+        assert response["statusCode"] == 400
+        assert len(nations_table.put_calls) == 0
+
+
+class TestWebhookIdempotency:
+    """Tests for Stripe webhook idempotency (duplicate event handling)."""
+
+    def test_record_event_id_first_then_duplicate(self) -> None:
+        """First call records and returns True; a replay returns False."""
+        events_table = MockDynamoDBTable()
+        mock_resource = MockDynamoDBResource(MockDynamoDBTable(), events_table)
+
+        with patch(
+            "src.lambdas.stripe_webhook.handler.get_dynamodb_resource",
+            return_value=mock_resource,
+        ):
+            assert record_event_id("evt_dedupe") is True
+            assert record_event_id("evt_dedupe") is False
+
+        # Marker stored exactly once, carries a TTL.
+        assert "evt_dedupe" in events_table.items
+        assert "expires_at" in events_table.items["evt_dedupe"]
+
+    def test_record_event_id_missing_id_processes(self) -> None:
+        """An event with no id cannot be deduped; we still process it."""
+        events_table = MockDynamoDBTable()
+        mock_resource = MockDynamoDBResource(MockDynamoDBTable(), events_table)
+
+        with patch(
+            "src.lambdas.stripe_webhook.handler.get_dynamodb_resource",
+            return_value=mock_resource,
+        ):
+            assert record_event_id("") is True
+
+        assert len(events_table.put_calls) == 0
+
+    def test_forget_event_id_allows_reprocessing(self) -> None:
+        """Removing a marker lets a later delivery be processed again."""
+        events_table = MockDynamoDBTable()
+        mock_resource = MockDynamoDBResource(MockDynamoDBTable(), events_table)
+
+        with patch(
+            "src.lambdas.stripe_webhook.handler.get_dynamodb_resource",
+            return_value=mock_resource,
+        ):
+            assert record_event_id("evt_retry") is True
+            forget_event_id("evt_retry")
+            # Marker gone -> a retry records it fresh.
+            assert record_event_id("evt_retry") is True
+
+    def test_duplicate_delivery_does_not_double_write(self) -> None:
+        """A replayed checkout webhook must not create the nation twice."""
+        nations_table = MockDynamoDBTable()
+        events_table = MockDynamoDBTable()
+        mock_resource = MockDynamoDBResource(nations_table, events_table)
+
+        event_body = {
+            "id": "evt_duplicate",
+            "type": "checkout.session.completed",
+            "data": {
+                "object": {
+                    "customer": TEST_CUSTOMER_ID,
+                    "subscription": TEST_SUBSCRIPTION_ID,
+                    "customer_email": TEST_EMAIL,
+                    "metadata": {"nation_slug": TEST_NATION_SLUG},
+                }
+            },
+        }
+        body = json.dumps(event_body)
+        signature = create_stripe_signature(body, TEST_WEBHOOK_SECRET)
+        lambda_event = {"body": body, "headers": {"Stripe-Signature": signature}}
+
+        with (
+            patch(
+                "src.lambdas.stripe_webhook.handler.get_stripe_webhook_secret",
+                return_value=TEST_WEBHOOK_SECRET,
+            ),
+            patch(
+                "src.lambdas.stripe_webhook.handler.get_dynamodb_resource",
+                return_value=mock_resource,
+            ),
+        ):
+            first = handler(lambda_event, None)
+            second = handler(lambda_event, None)
+
+        assert first["statusCode"] == 200
+        assert json.loads(first["body"]) == {"received": True}
+
+        # Second delivery is acknowledged but treated as a duplicate.
+        assert second["statusCode"] == 200
+        assert json.loads(second["body"]) == {"received": True, "duplicate": True}
+
+        # The nation record was created exactly once.
+        assert len(nations_table.put_calls) == 1
+
+    def test_failed_processing_removes_marker_for_retry(self) -> None:
+        """If a handler raises, the marker is removed so Stripe can retry."""
+        nations_table = MockDynamoDBTable()
+        events_table = MockDynamoDBTable()
+        mock_resource = MockDynamoDBResource(nations_table, events_table)
+
+        # Missing nation_slug -> handle_checkout_completed raises ValueError.
+        event_body = {
+            "id": "evt_fail",
+            "type": "checkout.session.completed",
+            "data": {
+                "object": {
+                    "customer": TEST_CUSTOMER_ID,
+                    "subscription": TEST_SUBSCRIPTION_ID,
+                    "metadata": {"plan": "nat"},
+                }
+            },
+        }
+        body = json.dumps(event_body)
+        signature = create_stripe_signature(body, TEST_WEBHOOK_SECRET)
+        lambda_event = {"body": body, "headers": {"Stripe-Signature": signature}}
+
+        with (
+            patch(
+                "src.lambdas.stripe_webhook.handler.get_stripe_webhook_secret",
+                return_value=TEST_WEBHOOK_SECRET,
+            ),
+            patch(
+                "src.lambdas.stripe_webhook.handler.get_dynamodb_resource",
+                return_value=mock_resource,
+            ),
+        ):
+            response = handler(lambda_event, None)
+
+        # Validation failure -> 400, and the marker was rolled back.
+        assert response["statusCode"] == 400
+        assert "evt_fail" not in events_table.items
+        assert events_table.delete_calls == [{"event_id": "evt_fail"}]

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,69 @@
+"""
+Unit tests for shared nation_slug validation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.lambdas.shared.validation import (
+    InvalidNationSlugError,
+    is_valid_nation_slug,
+    validate_nation_slug,
+)
+
+
+VALID_SLUGS = [
+    "testnation",
+    "my-nation",
+    "nation123",
+    "a",
+    "a" * 63,
+    "0-9-abc",
+]
+
+INVALID_SLUGS = [
+    "",  # empty
+    "UPPER",  # uppercase
+    "Mixed-Case",
+    "has space",
+    "under_score",
+    "dots.here",
+    "slash/here",
+    "../../etc/passwd",  # path traversal
+    "nation!",  # punctuation
+    "a" * 64,  # too long (DNS label ceiling is 63)
+    "naïve",  # non-ascii
+]
+
+
+@pytest.mark.parametrize("slug", VALID_SLUGS)
+def test_is_valid_accepts(slug: str) -> None:
+    assert is_valid_nation_slug(slug) is True
+
+
+@pytest.mark.parametrize("slug", INVALID_SLUGS)
+def test_is_valid_rejects(slug: str) -> None:
+    assert is_valid_nation_slug(slug) is False
+
+
+def test_is_valid_rejects_non_str() -> None:
+    assert is_valid_nation_slug(None) is False  # type: ignore[arg-type]
+    assert is_valid_nation_slug(123) is False  # type: ignore[arg-type]
+    assert is_valid_nation_slug(["testnation"]) is False  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("slug", VALID_SLUGS)
+def test_validate_returns_slug(slug: str) -> None:
+    assert validate_nation_slug(slug) == slug
+
+
+@pytest.mark.parametrize("slug", INVALID_SLUGS)
+def test_validate_raises(slug: str) -> None:
+    with pytest.raises(InvalidNationSlugError):
+        validate_nation_slug(slug)
+
+
+def test_invalid_error_is_value_error() -> None:
+    """InvalidNationSlugError is a ValueError so handlers can catch broadly."""
+    assert issubclass(InvalidNationSlugError, ValueError)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -34,6 +34,9 @@ INVALID_SLUGS = [
     "nation!",  # punctuation
     "a" * 64,  # too long (DNS label ceiling is 63)
     "naïve",  # non-ascii
+    "legit-slug\n",  # trailing newline ($ anchor bypass — must use \Z)
+    "legit\nslug",  # embedded newline
+    "legit-slug\r\n",  # CRLF
 ]
 
 


### PR DESCRIPTION
Closes #13.

## What
- **nation_slug validation** (`src/lambdas/shared/validation.py`): enforces `^[a-z0-9-]{1,63}$` at every entry point; invalid values rejected with 400 before the slug is used in DynamoDB keys, Secrets Manager names, or NB API URLs.
- **Idempotent Stripe webhook**: processed Stripe event IDs are persisted in DynamoDB (TTL); duplicate deliveries no-op, so Stripe's legitimate retries don't double-write nation records.

## Verified
- `pytest -q` → **596 passed** (+23 new: invalid-slug and duplicate-event cases)
- `mypy src/` → clean (23 files)

## Provenance
Authored by a pr-driver Opus drive that hit the 80-turn ceiling before it could commit/push; the working tree was preserved, independently re-verified (tests + mypy) from the main session, then committed and opened here. **No adversarial self-review ran** (the drive was cut off before that step) — worth a careful human/`/ship` review of the validation entry points and the webhook idempotency table wiring.